### PR TITLE
Add hispid3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Archive of prior TDWG standards.
 * [Index Herbariorum. part I: The herbaria of the world](/index-herbariorum-part-i)
 * [Botanico periodicum huntianum supplementum](/botanico-periodicum-huntianum-supplementum)
 * [XDF - A language for the definition and exchange of biological data sets](/xdf)
+* [HISPID3 - Herbarium Information Standards and Protocols for Interchange of Data](/hispid3)

--- a/hispid3/README.md
+++ b/hispid3/README.md
@@ -1,0 +1,23 @@
+# HISPID3 - Herbarium Information Standards and Protocols for Interchange of Data
+
+* **Download**: [Download](/download/110-540-1-RV.html)
+* **Status**: TDWG prior standard
+* **Category**: Technical specification
+* **TDWG task group**: Observation and Specimen Records (OSR)
+* **Date submitted**: 2006-11-24
+* **Date published**: 1996-10-01
+* **Last modified**: 2007-05-11
+
+## Abstract
+
+The 'Herbarium Information Standards and Protocols for Interchange of Data' (HISPID) is a standard format for the interchange of electronic herbarium specimen information. HISPID has been developed by a committee of representatives from all major Australian herbaria. This interchange standard was first published in 1989, with a revised version published in 1993.
+
+HISPID3 is an accession-based interchange standard. Although many fields refer to attributes of the taxon they should be construed as applying to the specimen represented by the record, not to the taxon per se. The interchange of taxonomic, nomenclatural, bibliographic, typification, rare and endangered plant conservation, and other related information is not dealt with in this standard, unless it specifically refers to a particular accession (record).
+
+This data dictionary is concerned primarily with data interchange standards but has considerable relevance to database structure since the task of preparing interchange files is simplified if the data fields of the despatching and receiving databases match, as far as possible, the interchange standard. If differences do exist then, generally, it is easier to combine data fields than it is to dissect them in a reliable manner. Fields that are concatenated are frequently heterogeneous in their nature and many preclude the possibility of rearranging the data contained within such fields.
+
+The fields discussed in this data dictionary cover most of the herbarium and botanic gardens sphere of activity and have been arranged in groups of similar types of information. In many cases these groups may coincide with separate well-defined tables (or databases) of structurally similar records.
+
+The challenge for herbarium data managers is to decide whether the data are to be efficiently exchanged as discrete but related tables (databases) or as a larger single flat file that may have to be appropriately dismembered by the receiving institution. Some database packages are able to stack multiple values in a single field. This useful data structure complicates the interchange format and will not be used at this stage.
+
+Also available at http://plantnet.rbgsyd.nsw.gov.au/HISCOM/HISPID/HISPID3/H3.html

--- a/hispid3/download/110-540-1-RV.html
+++ b/hispid3/download/110-540-1-RV.html
@@ -1,0 +1,7493 @@
+
+<html>
+
+<head>
+
+<!---
+Prepared by Barry Conn, November 1996; 
+Modified by Barry Conn, 12 May 1998 
+Modified by Ricardo Pereira, 11 May 2007 
+--->
+
+<title>HISPID 3 - The Full Document</title>
+<meta NAME="GENERATOR" CONTENT="Microsoft FrontPage 3.0">
+
+<body bgcolor="#ffffff">
+
+<p align="center"><b><font face="Calisto MT" size="7" color="#008000">HISPID3</font><font SIZE="6"><br>
+</font></b></p>
+
+<p align="center"><b><font face="Calisto MT" size="3" color="#008000">Herbarium
+Information Standards and Protocols for Interchange of Data<br>
+</font></b></p>
+
+<p align="center"><font face="Calisto MT" size="3" color="#008000"><b>Version 3<br>
+</b></font></p>
+
+<p align="center"><font face="Calisto MT" size="3" color="#008000"><b>Editor</b> <br>
+<b>Barry J. Conn</font><br>
+<br>
+</b></p>
+
+<p align="center"><b>Internet URL</b><br>
+<a href="http://www.tdwg.org/standards/110/">http://www.tdwg.org/standards/110/</a><font SIZE="2"> <br>
+</font></p>
+
+<p align="center"><font SIZE="2">� Council of Heads of Australian Herbaria <br>
+<br>
+</font></p>
+
+<p align="center"><b>Previous Versions of HISPID</b> </p>
+
+<p><b><font SIZE="1">Version 1:</font></b> </p>
+
+<p><font SIZE="1">Croft, J.R. (ed.) (1989). HISPID - Herbarium Information Standards and
+Protocols for Interchange of Data (Australian National Botanic Gardens: Canberra).<br>
+</font></p>
+
+<p><b><font SIZE="1">Version 2:</font></b> </p>
+
+<p><font SIZE="1">Whalen, A. (ed.) (1993). HISPID - Herbarium Information Standards and
+Protocols for Interchange of Data (National Herbarium of New South Wales: Sydney).<br>
+<br>
+<br>
+</font>
+
+<menu>
+  <li><font SIZE="1">As with all previous versions of HISPID, the preparation of the HISPID3
+    interchange standard is being coordinated by a committee of representatives from all major
+    Australian herbaria. Since 1995, the development of this standard has been coordinated by
+    the 'Herbarium Information Systems Committee' (HISCOM) (refer Internet URL
+    http://www.rbgsyd.gov.au/HISCOM).</font> </li>
+</menu>
+
+<p align="center"><b>TABLE OF CONTENTS<br>
+</b></p>
+
+<table border="0" width="100%">
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998600">INTRODUCTION</a></td>
+    <td width="1%">5</td>
+    <td width="65%"><a href="h3.html#_Toc366998626">RECORD IDENTIFICATION GROUP </a></td>
+    <td width="8%">29</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998601">Format of HISPID3</a></td>
+    <td width="1%">5</td>
+    <td width="65%"><a href="h3.html#_Toc366998627">'Full' Scientific Name </a></td>
+    <td width="8%">29</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998602">Definitions</a></td>
+    <td width="1%">6</td>
+    <td width="65%"><a href="h3.html#_Toc366998628">'Limited' Scientific Name </a></td>
+    <td width="8%">29</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998603">Italics</a></td>
+    <td width="1%">6</td>
+    <td width="65%"><a href="h3.html#_Toc366998629">Hybrids, Intergrades </a></td>
+    <td width="8%">29</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998604">Nulls</a></td>
+    <td width="1%">7</td>
+    <td width="65%"><a href="h3.html#_Toc366998630">Vernacular Names </a></td>
+    <td width="8%">30</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998605">Single character fields</a></td>
+    <td width="1%">7</td>
+    <td width="65%"><a href="h3.html#_Toc366998631">Higher Group Names </a></td>
+    <td width="8%">30</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998606">Codes</a></td>
+    <td width="1%">7</td>
+    <td width="65%"><a href="h3.html#_Toc366998632">Plant Name Authorities </a></td>
+    <td width="8%">30</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998607">Relevant Standards</a></td>
+    <td width="1%">7</td>
+    <td width="65%"><a href="h3.html#_Toc366998633">Other Comments </a></td>
+    <td width="8%">30</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998608">Summary of the important features of a HISPID3
+    file</a></td>
+    <td width="1%">8</td>
+    <td width="65%"><a href="h3.html#_Toc366998634">HYBRIDS, GRAFTS, CHIMAERA AND INTERGRADES </a></td>
+    <td width="8%">32</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998609">Example of the start and end of a HISPID3 file</a></td>
+    <td width="1%">8</td>
+    <td width="65%"><a href="h3.html#_Toc366998635">CULTIVATED PLANT NAMES </a></td>
+    <td width="8%">45</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998610">An example of a filled HISPID3 interchange file</a></td>
+    <td width="1%">9</td>
+    <td width="65%"><a href="h3.html#_Toc366998636">TYPIFICATION GROUP&nbsp; </a></td>
+    <td width="8%">50</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998611">FORMAT OF THE TEXT IN THIS DESCRIPTION OF A
+    HISPID3 FILE</a></td>
+    <td width="1%">11</td>
+    <td width="65%"><a href="h3.html#_Toc366998637">VERIFICATION GROUP</a></td>
+    <td width="8%">55</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998612">The full field name</a></td>
+    <td width="1%">11</td>
+    <td width="65%"><a href="h3.html#_Toc366998638">Identification Qualifiers </a></td>
+    <td width="8%">55</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998613">The transfer identifier code</a></td>
+    <td width="1%">11</td>
+    <td width="65%"><a href="h3.html#_Toc366998639">LOCATION GROUP </a></td>
+    <td width="8%">63</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998614">TDWG Short name</a></td>
+    <td width="1%">11</td>
+    <td width="65%"><a href="h3.html#_Toc366998640">Subsequent Location Fields </a></td>
+    <td width="8%">63</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998615">The field description</a></td>
+    <td width="1%">11</td>
+    <td width="65%"><a href="h3.html#_Toc363917741">Geocode Information </a></td>
+    <td width="8%">63</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998616">Relevant standards</a></td>
+    <td width="1%">11</td>
+    <td width="65%"><a href="h3.html#_Toc366998642">Spatial Data Interchange </a></td>
+    <td width="8%">64</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998617">Domain/Range/Values</a></td>
+    <td width="1%">11</td>
+    <td width="65%"><a href="h3.html#_Toc366998643">HABITAT GROUP </a></td>
+    <td width="8%">79</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998618">Comments</a></td>
+    <td width="1%">11</td>
+    <td width="65%"><a href="h3.html#_Toc366998644">COLLECTION GROUP </a></td>
+    <td width="8%">85</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998619">Rules</a></td>
+    <td width="1%">11</td>
+    <td width="65%"><a href="h3.html#_Toc366998645">Subsequent Collection Fields </a></td>
+    <td width="8%">85</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998620">Notes</a></td>
+    <td width="1%">11</td>
+    <td width="65%"><a href="h3.html#_Toc366998646">KIND OF COLLECTION, ADDITIONAL COMPONENTS and
+    VOUCHER COLLECTIONS</a> </td>
+    <td width="8%">93</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998621">FILE IDENTIFICATION FIELDS</a></td>
+    <td width="1%">13</td>
+    <td width="65%"><a href="h3.html#_Toc366998647">ADDITIONAL DATA GROUP </a></td>
+    <td width="8%">103</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998622">FILE IDENTIFIER GROUP</a></td>
+    <td width="1%">13</td>
+    <td width="65%"><a href="h3.html#_Toc366998648">LOAN GROUP </a></td>
+    <td width="8%">111</td>
+  </tr>
+  <tr>
+    <td width="40%"><a href="h3.html#_Toc366998623">ACCESSION INFORMATION Fields</a></td>
+    <td width="1%">21</td>
+    <td width="65%"><a href="h3.html#_Toc366998649">DATA ENTRY AND EDIT GROUP </a></td>
+    <td width="8%">117</td>
+  </tr>
+  <tr>
+    <td width="62%"><a href="h3.html#_Toc366998624">ACCESSION IDENTIFIER GROUP</a></td>
+    <td width="10%">21</td>
+    <td width="65%">INDEX</td>
+    <td width="8%">121</td>
+  </tr>
+  <tr>
+    <td width="62%"><a href="h3.html#_Toc366998625">BASIS OF RECORD GROUP </a></td>
+    <td width="10%">25</td>
+    <td width="65%"></td>
+    <td width="8%"></td>
+  </tr>
+</table>
+
+<p>:&nbsp; </p>
+
+<h1><a NAME="_Toc366998600">INTRODUCTION</a><br>
+</h1>
+
+<p><font SIZE="2">The 'Herbarium Information Standards and Protocols for Interchange of
+Data' (HISPID) is a standard format for the interchange of electronic herbarium specimen
+information. HISPID has been developed by a committee of representatives from all major
+Australian herbaria. This interchange standard was first published in 1989, with a revised
+version published in 1993.<br>
+</font></p>
+
+<p><font SIZE="2">HISPID3 is an accession-based interchange standard. Although many fields
+refer to attributes of the taxon they should be construed as applying to the specimen
+represented by the record, not to the taxon <i>per se</i>. The interchange of taxonomic,
+nomenclatural, bibliographic, typification, rare and endangered plant conservation, and
+other related information is not dealt with in this standard, unless it specifically
+refers to a particular accession (record).<br>
+</font></p>
+
+<p><font SIZE="2">This data dictionary is concerned primarily with data interchange
+standards but has considerable relevance to database structure since the task of preparing
+interchange files is simplified if the data fields of the despatching and receiving
+databases match, as far as possible, the interchange standard. If differences do exist
+then, generally, it is easier to combine data fields than it is to dissect them in a
+reliable manner. Fields that are concatenated are frequently heterogeneous in their nature
+and many preclude the possibility of rearranging the data contained within such fields.<br>
+</font></p>
+
+<p><font SIZE="2">The fields discussed in this data dictionary cover most of the herbarium
+and botanic gardens sphere of activity and have been arranged in groups of similar types
+of information. In many cases these groups may coincide with separate well�defined tables
+(or databases) of structurally similar records.<br>
+</font></p>
+
+<p><font SIZE="2">The challenge for herbarium data managers is to decide whether the data
+are to be efficiently exchanged as discrete but related tables (databases) or as a larger
+single flat file that may have to be appropriately dismembered by the receiving
+institution. Some database packages are able to stack multiple values in a single field.
+This useful data structure complicates the interchange format and will not be used at this
+stage.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998601">Format of HISPID3</a> </h2>
+
+<p><font SIZE="2">The 'Herbarium Information Systems Committee' (HISCOM) considered
+several format options for HISPID3. It was agreed that the interchange format of HISPID3
+would be a flat�file. This flat�file format was chosen because it was relatively simple
+and required minimal computer programming to enable the importing and exporting of data.
+Furthermore, this format was in agreement with that chosen for the 'International Transfer
+Format for Botanic Garden Plant Records (Version 2.00)(ITF2). Although, it was recognised
+that it was difficult to transfer relational (hierarchical) data in flat�file formats, it
+was decided to proceed with the publication of this version of HISPID so that electronic
+data interchange could be actively encouraged. It is hoped that future versions of HISPID
+will include the capability of transferring data such that the relational structure is
+maintained. <br>
+</font></p>
+
+<p><font SIZE="2">There have been several major changes incorporated into this version of
+the HISPID transfer format, namely: <br>
+</font></p>
+
+<p><font SIZE="2">(1) HISPID3 allows for the interchange of variable length fields. It is
+no longer restricted to a fixed length format.</font> </p>
+
+<p><font SIZE="2">(2) HISPID3 allows missing data to be omitted from the transfer file</font>
+</p>
+
+<p><font SIZE="2">(3) HISPID3 provides a protocol for interchanging (non-standard) data
+that are either not defined within this document or are in a form different to that define
+here.</font> </p>
+
+<p><font SIZE="2">(4) Apart from a few exceptions, HISPID3 does not evaluate the relevance
+of interchanging any of the specific fields described in this document</font> </p>
+
+<p><font SIZE="2">(5) The references to how data are stored in the major Australian
+herbarium databases has been deleted from this document</font> </p>
+
+<p><font SIZE="2">(6) HISPID3 has been developed in conjunction with ITF2 (International
+Transfer Format for Botanic Gardens Plant Records version 2.00) so that the two
+interchange standards are as compatible as possible.<br>
+</font></p>
+
+<p><font SIZE="2">The transfer format of HISPID3 is based on 'Information technology -
+Open Systems Interconnection - Specification of Abstract Syntax Notation One (ASN.1) '.
+International Standard ISO/IEC 8824, 2nd ed. (1990)(ISO/IEC: Gen�ve). <br>
+</font></p>
+
+<h2><a NAME="_Toc366998602">Definitions</a><font SIZE="2"> <br>
+</font></h2>
+
+<ul>
+  <li><font SIZE="2">A <b>HISPID3 file</b> is the total contents of the information
+    transferred. Each file begins with the file identifier '<b>startfile</b>' and ends with
+    the file identifier<b> 'endfile</b>' . Additional<b> </b>file header information is
+    provided before any of the record data.</font> </li>
+</ul>
+
+<ul>
+  <li><font SIZE="2">A <b>HISPID3 Record </b>includes all data associated with a single <b>Accession
+    Identifier</b> included in the overall file. Each record begins with the opened brace
+    character '<b>{</b>' and ends with the closed brace character '}'<b>.</b></font> </li>
+</ul>
+
+<ul>
+  <li><font SIZE="2">A <b>HISPID3 field</b> is the basic unit of information. The data of any
+    record are grouped into several separate fields of information. Each field is prefaced by
+    a unique field identifier. If the information pertaining to a certain field is to be
+    interchanged, then the appropriate unique field identifier must be interchanged with this
+    information. Each field is one line long and is always terminated by a comma (<b>,</b>).
+    The data within alphanumeric (text) fields are enclosed (delimited) by double quotation
+    marks (&quot;), whereas numeric fields are <i>not </i>enclosed by double quotation marks.
+    Fields are either 'required' for transfer in a HISPID3 Record (in which case a HISPID3
+    record is incomplete if one of these fields are excluded) or are 'optional'. For example,
+    the '<b>Institution Code'</b> field and the '<b>Accession Identifier'</b> are <i>always</i>
+    required in any valid HISPID3 record.</font> </li>
+</ul>
+
+<p><font SIZE="2">As far as practicable, raw data should be used. Interpretations or
+corrections in free text fields should be enclosed in square brackets: '[' and ']'.
+Omitted data should be represented by the ellipsis: '...'.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998603">Italics</a><font SIZE="4">:</font><font SIZE="5"> </font></h2>
+
+<p><font SIZE="2">Since the printable ASCII (EBDIC or UNICODE) character set does not
+include <i>italicised</i> characters, these are not included in the interchange file.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998604">Nulls:</a> </h2>
+
+<p><font SIZE="2">If information is not known for a field, then the field need not be
+included in the interchange file or else the field identifier may be interchanged
+unfilled. However, if the value of the <b>Collector's Identifier</b> field is unknown,
+then the default value should be 's.n.'.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998605">Single character fields</a><font SIZE="4">:</font><font SIZE="5"> </font></h2>
+
+<p><font SIZE="2">In general, single character (flag) fields have not been included in
+this standard because of the difficulty of detecting data entry errors.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998606">Codes</a><font SIZE="4">:</font><font SIZE="5"> </font></h2>
+
+<p><font SIZE="2">As for the 'single character' fields (above), codes are mostly not
+included in this standard because of the difficulty of detecting data entry errors.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998607">Relevant Standards</a><font SIZE="2"> </font></h2>
+
+<p><font SIZE="2">The fields included in this interchange standard are a compilation from
+the following sources: <br>
+</font></p>
+
+<p>ABIS <font SIZE="2">Australian Biotaxonomic/Biogeographic Information System</font> </p>
+
+<p>(Australian Biological Resources Study � ABRS)<font SIZE="2"> <br>
+</font></p>
+
+<p><font SIZE="2">ICBN International Code of Botanical Nomenclature</font> </p>
+
+<p>(International Association of Plant Taxonomists � IAPT)<br>
+</p>
+
+<p>ITF<font SIZE="2"> International Transfer Format for Botanic Gardens Plant Records <br>
+</font></p>
+
+<p><font SIZE="2">ITFBGPR (Botanic Gardens Conservation International � BGCI) <br>
+</font></p>
+
+<p>ITRF International Earth Rotation Service Terrestrial Reference Frame <br>
+</p>
+
+<p>MFN<font SIZE="2"> Minimal Functional Nomenclator, also known as:</font> </p>
+
+<p>DSTI<font SIZE="2"> Database Standards for Taxonomic Information</font> </p>
+
+<p>(Taxonomic Database Working Group � TDWG)<br>
+</p>
+
+<p>PECS <font SIZE="2">Plant Existence and Categorisation Scheme, also known as:</font> </p>
+
+<p>POSS <font SIZE="2">Plant Occurrence and Status Scheme</font> </p>
+
+<p>(World Conservation Monitoring Centre � WCMC Threatened Plants Unit - TPU<font SIZE="2">) <br>
+</font></p>
+
+<p>SDTS Spatial Data Transfer Standard<br>
+</p>
+
+<p><font SIZE="2">TDWG Taxonomic Database Working Group<br>
+</font></p>
+
+<p>TLR<font SIZE="2"> Type and Lectotypification Registers</font> </p>
+
+<p>(Taxonomic Database Working Group � TDWG)<br>
+</p>
+
+<p>WGSUB<font SIZE="2"> World Geographical System for Use in Botany</font> </p>
+
+<p>(Taxonomic Database Working Group � TDWG)<br>
+</p>
+
+<p>XDF<font SIZE="2"> Language for the Definition and Exchange of Biological Data Sets </font></p>
+
+<p><font SIZE="2">(Taxonomic Database Working Group � TDWG)<br>
+</font></p>
+
+<h2><a NAME="_Toc366998608">Summary of the important features of a HISPID3 file</a><font SIZE="2">: <br>
+</font></h2>
+
+<p><font SIZE="2"><b>a) Each field is prefaced by an unique identifier</b> <b>this refers
+to the fields which describe the contents of the file, as well as to those which describe
+the information contained in each record);</b></font> </p>
+
+<p><b><font SIZE="2">b) Each unique identifier must begin with a lowercase letter (a-z)
+and cannot contain any spaces;</font></b> </p>
+
+<p><b><font SIZE="2">c) A transfer file begins with the file identifier 'startfile';</font></b>
+
+<ol>
+  <li><b><font SIZE="2">Each record begins with the opened brace character '{';</font></b> </li>
+  <li><b><font SIZE="2">Each record ends with the closed brace character '}';</font></b> </li>
+</ol>
+
+<p><b><font SIZE="2">f) Variable length fields are allowed;</font></b> </p>
+
+<p><b><font SIZE="2">g) Fields can be omitted from the transfer file if there is no
+information available for that field;</font></b> </p>
+
+<p><b><font SIZE="2">h) Alphanumeric data are enclosed by double quotation marks (&quot;);</font></b>
+</p>
+
+<p><b><font SIZE="2">i) Numeric data are not enclosed by double quotation marks;</font></b>
+</p>
+
+<p><b><font SIZE="2">j) Each field and each file information is one line long and is
+terminated by a comma (,);</font></b> </p>
+
+<p><b><font SIZE="2">k) Each transfer file ends with the file identifier 'endfile'. <br>
+<br>
+</font></b></p>
+
+<h2><a NAME="_Toc366998609">Example of the start and end of a HISPID3</a> file<font SIZE="2">: <br>
+</font></h2>
+
+<table>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">startfile</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">version </font></td>
+    <td WIDTH="470"><font SIZE="2">HISPID version</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">numrecords </font></td>
+    <td WIDTH="470"><font SIZE="2">number of records in this file</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">datefile </font></td>
+    <td WIDTH="470"><font SIZE="2">date to which the file refers</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">institute </font></td>
+    <td WIDTH="470"><font SIZE="2">full name of institution supplying information</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">contact </font></td>
+    <td WIDTH="470"><font SIZE="2">contact name</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">address </font></td>
+    <td WIDTH="470"><font SIZE="2">postal address</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">phone </font></td>
+    <td WIDTH="470"><font SIZE="2">telephone number</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">fax </font></td>
+    <td WIDTH="470"><font SIZE="2">fax number</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">email </font></td>
+    <td WIDTH="470"><font SIZE="2">email address</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">nonstandard </font></td>
+    <td WIDTH="470"><font SIZE="2">optional field to describe any non-standard fields added to
+    the HISPID3 transfer file</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">fileaction </font></td>
+    <td WIDTH="470"><font SIZE="2">descriptor flag indicating how records of file should be
+    processed</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">filedescriptor </font></td>
+    <td WIDTH="470"><font SIZE="2">descriptor flag indicating the nature of the records
+    included in file</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">content </font></td>
+    <td WIDTH="470"><font SIZE="2">contents of the file and other comments</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">{ </font></td>
+    <td WIDTH="470"><font SIZE="2">start of a record</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">insid </font></td>
+    <td WIDTH="470"><font SIZE="1">the standard 'Index Herbariorum' code for the herbarium to
+    which the plant record refers</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">accid </font></td>
+    <td WIDTH="470"><font SIZE="2">accession number</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">...</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">...</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">|</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">|</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">...</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">} </font></td>
+    <td WIDTH="470"><font SIZE="2">end of record</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">{ </font></td>
+    <td WIDTH="470"><font SIZE="2">start of next record</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">insid</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">accid</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">...</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">|</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">|</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">...</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">} </font></td>
+    <td WIDTH="470"><font SIZE="2">end of next record</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">endfile </font></td>
+    <td WIDTH="470"><font SIZE="2">end of file</font> </td>
+  </tr>
+</table>
+
+<h2><a NAME="_Toc366998610">An example of a filled HISPID3 interchange file</a><font SIZE="2"> <br>
+</font></h2>
+
+<table>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">startfile</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">version </font></td>
+    <td WIDTH="470"><font SIZE="2">&quot;HISPID3&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">numrec </font></td>
+    <td WIDTH="470"><font SIZE="2">2,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">datefile </font></td>
+    <td WIDTH="470"><font SIZE="2">19951202,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">institute </font></td>
+    <td WIDTH="470"><font SIZE="2">&quot;National Herbarium of New South Wales (NSW)&quot;,</font>
+    </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">contact </font></td>
+    <td WIDTH="470"><font SIZE="2">&quot;Gary Chapple&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">address </font></td>
+    <td WIDTH="470"><font SIZE="2">&quot;Royal Botanic Gardens, Mrs Macquaries Road, Sydney
+    NSW 2000, Australia&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">phone </font></td>
+    <td WIDTH="470"><font SIZE="2">612 92318164,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">fax </font></td>
+    <td WIDTH="470"><font SIZE="2">612 92517231,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">email </font></td>
+    <td WIDTH="470"><font SIZE="2">&quot;gary@rbgsyd.gov.au&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">fileaction </font></td>
+    <td WIDTH="470"><font SIZE="2">&quot;insert&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">filedescriptor </font></td>
+    <td WIDTH="470"><font SIZE="2">&quot;exchange&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">content </font></td>
+    <td WIDTH="470"><font SIZE="2">&quot;Herbarium exchange data of various species from NSW
+    to CANB&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">{</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">insid </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;NSW&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">accid </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;390839&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">fam </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Loranthaceae&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">gen </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Amyema&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">sp </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;pendulum&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">isprk </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;subsp.&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">isp </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;longifolium&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">vnam </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Wiecek, B.M.&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">vdat </font></td>
+    <td WIDTH="470"><font SIZE="1">1995,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">prot </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Wild&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">cou </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;AUSTRALIA&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">pru </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;NSW&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">sru </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Central W. Slopes&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">loc </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Mount Bolton, Moura&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">latdeg </font></td>
+    <td WIDTH="470"><font SIZE="1">33,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">latmin </font></td>
+    <td WIDTH="470"><font SIZE="1">15,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">latdir </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;S&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">londeg </font></td>
+    <td WIDTH="470"><font SIZE="1">148,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">lonmin </font></td>
+    <td WIDTH="470"><font SIZE="1">24,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">londir </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;E&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">cnam </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Baeuerlen, W.&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">cdat </font></td>
+    <td WIDTH="470"><font SIZE="1">190103,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">hab </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;On Eucalyptus macrorrhyncha.&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">misc </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Donated by Museum of Applied Arts &amp; Sciences,
+    1979.&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">}</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">{</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">insid </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;NSW&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">accid </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;248836&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">fam </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Asclepiadaceae&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">gen </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Cynanchum&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">sp </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;pedunculatum&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">vnam </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Hill, K.D.&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">vdat </font></td>
+    <td WIDTH="470"><font SIZE="1">1992,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">prot </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Wild&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">cou </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;AUSTRALIA&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">pru </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;WA&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">sru </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Fortescue&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">loc </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Mount Lois.&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">alt </font></td>
+    <td WIDTH="470"><font SIZE="1">800,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">latdeg </font></td>
+    <td WIDTH="470"><font SIZE="1">22,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">latmin </font></td>
+    <td WIDTH="470"><font SIZE="1">06,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">latdir </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;S&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">londeg </font></td>
+    <td WIDTH="470"><font SIZE="1">117,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">lonmin </font></td>
+    <td WIDTH="470"><font SIZE="1">44,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">londir </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;E&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">geoacy </font></td>
+    <td WIDTH="470"><font SIZE="1">0.05,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">hab </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Summit of mountain. Red loam derived from iron-rich
+    shale.&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">cnam </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Wilson, Peter G.&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">cid </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;1031&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">cnam2 </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Rowe, R.&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">cdat </font></td>
+    <td WIDTH="470"><font SIZE="1">19910911,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">cnot </font></td>
+    <td WIDTH="470"><font SIZE="1">&quot;Rare. Scrambler. Flowers white; fruit green.&quot;,</font>
+    </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="1">}</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">endfile</font></td>
+    <td WIDTH="470"></td>
+  </tr>
+</table>
+
+<h1><a NAME="_Toc366998611"><font SIZE="5">FORMAT OF THE TEXT IN THIS DESCRIPTION OF A
+HISPID3 FILE</font></a><font SIZE="1"> <br>
+</font></h1>
+
+<p><font SIZE="2">The herbarium data fields for information interchange are listed below
+in the following format:<br>
+</font></p>
+
+<h2><a NAME="_Toc366998612">The full field name:</a> </h2>
+
+<p><font SIZE="2">The name of the discrete piece of information within the file or within
+each record.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998613">The transfer identifier code<font SIZE="2">:</a> </font></h2>
+
+<p><font SIZE="2">The standard codes used as file or field identifiers in the transfer
+file.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998614">TDWG Short name:</a> </h2>
+
+<p><font SIZE="2">A short, meaningful�sounding single�word name for the field, proposed
+by TDWG.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998615">The field description:</a> </h2>
+
+<p><font SIZE="2">A general elaboration of the field name.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998616">Relevant standards:</a> </h2>
+
+<p><font SIZE="2">The existence of this type of data in any other published or proposed
+biological standards. <br>
+</font></p>
+
+<h2><a NAME="_Toc366998617">Domain/Range/Values:</a> </h2>
+
+<p><font SIZE="2">The type of data allowed in this field, the range of values, or
+individual allowable values, and capitalisation. <br>
+</font></p>
+
+<h2><a NAME="_Toc366998618">Comments:</a> </h2>
+
+<p><font SIZE="2">Any other remarks on the use or application of these data and its
+relationships to other data. Any conflicts or problems in the application of these data
+types.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998619">Rules:</a> </h2>
+
+<p><font SIZE="2">Additional information to that provided in <i>Comments</i> explaining
+the rules applying to these data.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998620">Notes:</a> </h2>
+
+<p><font SIZE="2">Additional comments to those provided in <i>Comments</i> and <i>Rules</i>.<br>
+</font></p>
+
+<h1><a NAME="_Toc366998621"><font SIZE="5">FILE IDENTIFICATION FIELDS</font></a><font SIZE="6"> <br>
+</font></h1>
+
+<h3><a NAME="_Toc366998622">FILE IDENTIFIER GROUP:</a><br>
+</h3>
+
+<p>This group of fields provides information about the file. These fields are required so
+that the receiving institution knows what to do with the incoming data.<br>
+<br>
+<br>
+<br>
+</p>
+
+<hr>
+
+<h4><font SIZE="2">Start of HISPID3 File</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">startfile <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The beginning of the transfer file has the file
+identifier 'startfile' only. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: This field has the value 'startfile' only
+(all in lowercase). <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917592">End of HISPID3</a> File</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">endfile <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The end of the transfer file has the file identifier
+'endfile' only.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: This field has the value 'endfile' only (all
+in lowercase).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: To be found at the very end of a HISPID3 file
+indicating the end of file. The description of this file identifier has been included here
+so that it can be considered together with the 'startfile' identifier. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917593">Version of File</a></font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">version <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The HISPID Version used in the current HISPID
+transfer file.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; the version number prefaced by
+the acronym 'HISPID' (all in uppercase). <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Although it is expected that the latest version of
+HISPID will normally be used for the transfer format, the format of earlier versions are
+allowable. The 'HISPID Version August 1993' should be referred to as HISPID2 and the
+original version of HISPID (1989) as HISPID1. This current version should be referred to
+as HISPID3. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917594">Number of Records in File</a></font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">numrecords <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The total number of records expressed as an integer.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer only.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917595">Date of File</a></font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">datefile <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The date of compilation of the current HISPID file.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; year (4 digits) followed by month
+(2 digits) and then day (2 digits), without spaces between each. That is, YYYYMMDD. For
+example, the 6th July 1987 would be transferred in the form 19870706 (refer <b>Collection
+Date</b> for further details).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This date format consists of year month day in that
+order.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917596">Name of Institution Supplying </a>Information</font>
+</h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">institute <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The name in full of the institution sending the
+current HISPID file.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917597">Contact </a>Name</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">contact <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The full name of the contact person within the
+institution.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917598">Address of Institution Sending </a>File</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">address <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The full postal address of the sending institution.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: The address should be displayed as continuous text, no
+line breaks, only commas and spaces as required.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917599">Telephone Number of </a>Institution</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">phone </font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The telephone number of the Contact Person.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: The use of national and international codes depends on
+the circumstances of the sending and receiving institutions.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917600">Facsimile Number of </a>Institution</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">fax <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The facsimile number of the Contact person.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: The use of national and international codes depends on
+the circumstances of the sending and receiving institutions.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917601">Email Address of </a>Institution</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">email <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The email address of the Contact person.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917602">Non-Standard </a>Option</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">nonstandard <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: This field allows for the inclusion of data or
+standards that have not been included in this publication. The data is likely to be of
+particular interest to the sending and receiving institutions, who wish to use a HISPID
+type format for data fields which have not been described in this standard.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; the field identifier
+'nonstandard' is followed by a suggested unique field identifier (all lowercase (a-z) or
+at least first letter lowercase) to be used in the transfer file; which is followed by a
+brief explanation (if necessary); the syntax of the data (whether alphanumeric or
+numeric); and the reference to the standard used in this new field (if necessary)(all
+enclosed by round brackets and, within, each separated by a semicolon and space)(refer
+example below).<br>
+</font></p>
+
+<p><font SIZE="2">If the data for any one standard are being transferred in several
+fields, then each unique field identifier is separated by a space followed by the
+necessary explanatory information in round brackets.<br>
+</font></p>
+
+<p><font SIZE="2">If more than one non-standard HISPID field (based on different
+standards) is being used in the transfer file then each must be separated by a semicolon
+and space (; )(refer example, below).<br>
+</font></p>
+
+<p><font SIZE="2">Since this field is alphanumeric (text), the data must be enclosed by
+double quotations (&quot;); all data must be on one line; and the field must end with a
+comma (,).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Note</i>: Since conformity with the HISPID standard is an agreed
+(essential) requirement for institutions interchanging data according to HISPID3 format,
+institutions are strongly urged to modify their interchange data so that they conform with
+one or more of the current HISPID3 fields. However, when circumstances preclude this, the <b>Non-Standard
+Option</b> may be used to interchange such data. If an institution wishes to interchange
+non-standard data, then they are requested to notify the HISPID coordinator (editor) so
+that these additional fields can be considered for inclusion in future versions of HISPID.
+<br>
+</font></p>
+
+<p><font SIZE="2">In the following example, the 'nonstandard' information is presented on
+more than one line for readability.<br>
+</font></p>
+
+<p><i><font SIZE="2">Example 1:</font></i> </p>
+
+<p><font SIZE="2">nonstandard &quot;pol (Pollinator; alphanumeric - scientific name of
+pollinator and authority at lowest level name or epithet); arch (Plant architectural
+models; alphanumeric; F. Hall� et al<i>.</i> 1978. 'Tropical trees and forests',
+Springer-Verlag: Berlin)&quot;,<br>
+</font></p>
+
+<p><i><font SIZE="2">Example 2:</font></i> </p>
+
+<p><font SIZE="2">If an institution is unable to provide information in the format of any
+particular HISPID3 field, as here defined, because they combine two or more of these
+fields together in such a way that the data are unable to be separated, then the <b>Non-Standard
+</b>option can be used.<br>
+</font></p>
+
+<p><font SIZE="2">For example, if an institution combines the <b>Substrate</b> and <b>Soil
+Type</b> fields together, and the <b>Vegetation</b> and <b>Associated Species</b> Fields
+together, in such a way that they are unable to separate these elements into separate
+fields, then a new 'Transfer code' for each pair of information can be formed, with the
+'Transfer codes' of the segregate fields cited in round brackets, and each of these
+Transfer codes separated by a comma. It is then understood that the <i>Domain/Range/Values</i>
+and other <i>Comments</i> of each still applies.<br>
+</font></p>
+
+<p><font SIZE="2">nonstandard &quot;subsoil (sub, soil); vegass (veg, asspp)&quot;,<br>
+</font></p>
+
+<p><font SIZE="2"><b>subsoil </b>is the <b>nonstandard identifier for the combined
+Substrate</b> and <b>Soil Type </b>fields;</font> </p>
+
+<p><font SIZE="2"><b>vegass</b> is the <b>nonstandard</b> identifier for the combined <b>Vegetation</b>
+and <b>Associated Species</b> fields.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: The non-standard fields would have to be programmed
+into the receiving database, as well as into the HISPID insert program.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917603">File Action</a> Flag</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">fileaction <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: A field to indicate how the records of the file
+should be processed. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphabetic; this field must consist of one
+of the values in the table below: <br>
+</font></p>
+
+<table>
+  <tr>
+    <td WIDTH="111"><font SIZE="2"><i>Values in Field</i> </font></td>
+    <td WIDTH="425"><i><font SIZE="2">Meaning </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">delete </font></td>
+    <td WIDTH="425"><font SIZE="2">delete all records in file from institutional database
+    receiving transfer file</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">insert </font></td>
+    <td WIDTH="425"><font SIZE="2">all records in file to be added to receiving database</font>
+    </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">update </font></td>
+    <td WIDTH="425"><font SIZE="2">update relevant fields of all records in file in receiving
+    database </font></td>
+  </tr>
+</table>
+
+<p><font SIZE="2"><i>Comments</i>: This field should be used in conjunction with the <b>Description
+of File Contents and Other Comments</b> field (refer below). The 'delete' option is used
+when previously received collections are know to be sufficiently inaccurate that it is
+recommended that the specimen be removed from the herbarium. The reason for this would be
+explained in the <b>Description of File Contents and Other Comments</b> field (refer
+below).<br>
+</font></p>
+
+<p><font SIZE="2">The 'insert' option is used for new records being sent to the receiving
+database. This is the default value for all exchange data.<br>
+</font></p>
+
+<p><font SIZE="2">The 'update' option is used for records already held in the receiving
+database which have been modified and included in the current transfer file. This option
+would be used for returning redeterminations and other corrections to the receiving
+institutions. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917604">File Descriptor </a>Flag</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">filedescriptor <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: A field to indicate the nature of the records
+contained in the file.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphabetic; this field must consist of one
+of the values in the table below: <br>
+</font></p>
+
+<table>
+  <tr>
+    <td WIDTH="111"><font SIZE="2"><i>Values in Field</i> </font></td>
+    <td WIDTH="539"><i><font SIZE="2">Meaning </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">exchange </font></td>
+    <td WIDTH="539"><font SIZE="2">records in file to be added to receiving database as part
+    of exchange of herbarium material</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">loan </font></td>
+    <td WIDTH="539"><font SIZE="2">electronic herbarium data associated with loan of herbarium
+    material</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">repatriation </font></td>
+    <td WIDTH="539"><font SIZE="2">repatriation of electronic data (from duplicate material
+    held at sending institution to receiving institution) to the database held at the latter
+    institution.</font> </td>
+  </tr>
+</table>
+
+<p><font SIZE="2"><i>Comments</i>: These key values may be used to automatically implement
+the procedures to be followed by the receiving institution. This field should be used in
+conjunction with the <b>Description of File Contents and Other Comments</b> field (refer
+below).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917605">Description of File Contents and Other </a>Comments</font>
+</h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">content <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: A brief description of the content of the current
+HISPID file. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; free text.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Example 1</i>:<i> </i>Description of records being transferred as
+part of an herbarium loan:<br>
+</font></p>
+
+<table>
+  <tr>
+    <td WIDTH="102"><font SIZE="2">content </font></td>
+    <td WIDTH="350"><font SIZE="2">&quot;Herbarium loan 96/014, Myrtaceae data, from NSW to
+    MO&quot;,</font> </td>
+  </tr>
+</table>
+
+<p><font SIZE="2"><i>Example 2</i>:<i> </i>Description of transfer file containing
+corrections to the plant name (<b>Record Identification Group</b> of fields):<br>
+</font></p>
+
+<table>
+  <tr>
+    <td WIDTH="102"><font SIZE="2">content </font></td>
+    <td WIDTH="489"><font SIZE="2">&quot;Redeterminations and other corrections to the plant
+    name fields, from BRI to LAE&quot;, </font></td>
+  </tr>
+</table>
+
+<p><font SIZE="2"><i>Comments</i>: This field may be used in conjunction with the File
+Descriptor Flag (above). <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917606">Data Set </a>URL</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">daturl <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The internet URL (Universal Resource Locator) where
+the records in this file can be found.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: Internet URL, RFC 1738 (refer URL
+http://www.w3.org/pub/WWW/Addressing/rfc1738.txt or URL
+http://www.w3.org/pub/WWW/Addressing/URL/Overview.html) <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; any valid internet URL.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This information can refer to either a fixed export
+file, to an on-line query, or can link to a specimen database gateway.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h1><a NAME="_Toc366998623"><font SIZE="5">ACCESSION INFORMATION Fields</font></a><br>
+</h1>
+
+<h3><a NAME="_Toc366998624">ACCESSION IDENTIFIER GROUP:</a><br>
+</h3>
+
+<p><font SIZE="2">This group of fields identifies the data records of the transfer file,
+that is, it describes the accession-based (specimen-based) information being interchanged.
+It is essential that these fields match exactly for the various exchange options to work
+effectively.<br>
+</font></p>
+
+<p><font SIZE="2">The fields in this group include the <b>Institution Code</b> and <b>Accession
+Identifier</b>, as well as the Record defining field identifiers.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917609">Start of HISPID3 </a>Record</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">{ <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The single character } indicating the end of a
+HISPID3 Record. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Must contain the symbol '}' only.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: To be found at the end of each HISPID3 record
+indicating the end of the data of a record, prior to beginning the next record or the <b>endfile
+</b>identifier if it is the last record in the transfer file. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917611">Institution </a>Code</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">insid</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: HERBARIUM <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The standard code for the Institution to which the
+plant record refers.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: Index Herbariorum, International Directory
+for Botanic Gardens, ABIS, ITF, TLR<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: The code must consist of an entry of 1�7
+uppercase letters (A�Z), no embedded spaces. This field <i>must</i> be filled. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: When inserting the accession information into a
+receiving database, the <b>Institution Code</b> combines with the <b>Accession Identifier</b>
+to make up the unique Donor's accession identifier for each record. <br>
+</font></p>
+
+<p><font SIZE="2">It is perhaps not necessary to include this field in a 'home' database
+since it may be appended to the record as the interchange file is generated. However, it
+will be necessary if the herbarium chooses to keep records of other institutions'
+collections of particular groups (for research purposes for example). <br>
+</font></p>
+
+<p><font SIZE="2">A problem with this field may arise with herbaria associated with
+botanic gardens; it is desirable that the herbaria and botanic gardens have the same
+abbreviation. If the record is primarily referring to an herbarium voucher, then the
+herbarium code should always be used in the transfer file. The distinction between
+herbarium and living material can be handled by various flags in the Collection group.<br>
+</font></p>
+
+<p><font SIZE="2">If an institution's herbarium does <i>not </i>have an official code,
+then a temporary one should be assigned. However, it is essential that the institution
+receiving the transfer file is aware of the code being used. This information should be
+included in the <b>Description of File Contents and other Comments</b> field (refer
+above).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917612">Accession </a>Identifier</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">accid</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: UNIQUEID, ACCESSIONID<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The unique identifier of the record, often called
+'Accession Number', used internally by the institution to record each accession.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF, TLR</font> </p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; the <b>Accession Identifier</b>
+field may consist of any characters in the ASCII character set, no embedded spaces. <br>
+</font></p>
+
+<p><font SIZE="2">1. The <b>Accession Identifier</b> should be a unique set of characters
+that identifies each accession in the institution's own record system.</font> </p>
+
+<p><font SIZE="2">2. The same value of the <b>Accession Identifier</b> should not be used
+again for a separate, unrelated specimen in that institution.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments:</i> Institutions differ widely in the way they accession
+and record herbarium specimens with one result that numbering systems (sometimes multiple)
+have been applied in fundamentally different ways. In some institutions this number refers
+to a unique specimen accession number, in others the specimen parts are accessioned
+individually and each part (eg. multiple sheets) has its own accession number, but
+supplementary material such as spirit and fruit may carry the number of the first sheet.
+The application of different specimen/accession number systems is a source of potential
+confusion where the specimen number and accession number may or may not be the same thing.
+However, only the Accession Identifier is used in HISPID3. This single number will either
+identify the single herbarium material or the group of material (when several identifiers
+are used for different elements of an accession).<br>
+</font></p>
+
+<p><font SIZE="2">Unlike herbaria, many botanic gardens include punctuation within their
+Accession Identifier, eg. 82�BG�24�31. It is vital for an institution to be consistent
+on whether the punctuation is included in the HISPID3 transfer format.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h3><a NAME="_Toc366998625">BASIS OF RECORD GROUP</a> </h3>
+
+<p><font SIZE="2">This group consists of a single field which indicates the basis of the
+record being interchanged. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917614">Source of Record</a> Flag</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">recsou</font> </h6>
+
+<p><font SIZE="2"><b>TDWG Short name</b>: RECSOURCE, NATOBJECT<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: A code indication of the type of item to which the
+record refers. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphabetic; as defined below:<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="108"><i><font SIZE="2">Values in Field</font></i></td>
+    <td WIDTH="378"><i><font SIZE="2">Meaning </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="108"><font SIZE="2">Collection </font></td>
+    <td WIDTH="378"><font SIZE="2">Plant specimen</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="108"><font SIZE="2">Electronic </font></td>
+    <td WIDTH="378"><font SIZE="2">Electronic record only, specimen no longer available</font>
+    </td>
+  </tr>
+  <tr>
+    <td WIDTH="108"><font SIZE="2">Literature </font></td>
+    <td WIDTH="378"><font SIZE="2">Reference</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="108"><font SIZE="2">Observation </font></td>
+    <td WIDTH="378"><font SIZE="2">Observation, including photograph of plant, but not of
+    specimen</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="108"><font SIZE="2">Photograph </font></td>
+    <td WIDTH="378"><font SIZE="2">Photograph of specimen</font> </td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Comments</i>: The default should be '<b>Collection</b>' for a
+specimen�based record. In the absence of any other value, a specimen�based record is
+assumed.<br>
+</font></p>
+
+<p><font SIZE="2">The values '<b>Observation</b>' and '<b>Literature</b>' may be used when
+the presence of a taxon is solely based on an observation or a published reference to an
+herbarium specimen held in another institution (respectively). The value '<b>Electronic</b>'
+is used when the presence of a taxon is solely based on an electronic record of an
+herbarium specimen which is no longer available. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h3><a NAME="_Toc366998626">RECORD IDENTIFICATION GROUP</a> </h3>
+
+<p><font SIZE="2">This group of fields completely describes the botanical name of the
+record. These fields also enable the identification of cultivars and hybrids and
+intermediates using either binomials or hybrid formulae, as well as qualified
+identifications.<br>
+</font></p>
+
+<p><font SIZE="2">These fields enable the interchange of either the 'full' scientific
+(Latin) name of a plant or the 'limited' scientific name.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998627">'Full' Scientific Name</a><font SIZE="2"> <br>
+</font></h2>
+
+<ol>
+  <li><font SIZE="2">The 'full' scientific name includes the genus and species names, together
+    with all infraspecific names and ranks (where relevant) and all the appropriate
+    authorities. Such 'full' names are extremely useful, especially if the complete taxonomic
+    name of the taxon is required.</font> </li>
+</ol>
+
+<h2><a NAME="_Toc366998628">'Limited' Scientific </a></h2>
+
+<p><font SIZE="2">2. If a 'full' taxonomic name is not required, then an abbreviated
+('limited') scientific name can be used to precisely refer to the taxon. This option is
+also available in HISPID3. Such a 'limited' scientific name is transferred according to
+the following rules:<br>
+</font></p>
+
+<p><font SIZE="2">If only a species name is required then:</font> </p>
+
+<p><font SIZE="2"><i>only</i> the genus name and the specific epithet are required. The
+authority is not required unless there is some possibility of confusion between this
+species and a homonym.<br>
+</font></p>
+
+<p><font SIZE="2">If the record refers to an infraspecific taxon then:</font> </p>
+
+<p><font SIZE="2"><i>only</i> the genus name, specific epithet and the lowest level
+infraspecific epithet are required. The authority is not required unless there is some
+possibility of confusion between this infraspecific taxon and a homonym.<br>
+</font></p>
+
+<p><font SIZE="2">The module for the Plant Name is based on Bisby, F.A. (1994) 'Plant
+names in botanical databases', Plant Taxonomic Database Standard No. 3 Version 1.00 (TDWG
+/ Hunt: Pittsburgh). <br>
+</font></p>
+
+<h2><a NAME="_Toc366998629">Hybrids</a><font SIZE="4">, Intergrades</font><font SIZE="5"> </font></h2>
+
+<p><font SIZE="2">Hybrids and Intergrades present considerable problems for handling of
+their names in electronic storage and transfer. The system presented here differs from
+ITF2, in that it does not indicate the taxonomic rank at which the hybrization or
+intergradation occurs. For example, in HISPID3, if the <b>Hybrid Flag</b> field is filled,
+then the name of the 'first' parent is transferred in the 'default' HISPID3 name fields
+(eg. <b>Genus Name</b>, <b>Species Epithet</b>, <b>Infraspecific Epithet</b>) and the
+'second' parent is transferred in the 'hybrid' name fields (eg. <b>Genus Name Parent 2
+Hybrid</b>, <b>Species Epithet Parent 2 Hybrid</b>, <b>Infraspecific Epithet Parent 2
+Hybrid</b>). Unlike ITF2, this system readily allows for the interchange of hybrids and
+intergrades resulting from parents at different rank (eg. a hybrid between one species and
+the variety of another species). <br>
+</font></p>
+
+<h2><a NAME="_Toc366998630">Vernacular Names</a> </h2>
+
+<p><font SIZE="2">Although the application of vernacular (common) names is not as
+rigorously controlled as scientific names, and they vary greatly and are often not unique
+for individual species, institutions may wish to interchange this information. A suggested
+format for interchanging these data are included (refer <b>Vernacular Names</b>).<br>
+</font></p>
+
+<h2><a NAME="_Toc366998631">Higher Group Names</a><font SIZE="2"> </font></h2>
+
+<p><font SIZE="2">The names of higher groups such as suprafamilial groups and families are
+not required in the HISPID3 transfer file because each accepted genus name in the plant
+kingdom is unique. However, these data may be interchanged, using the fields <b>Suprafamilial
+Group Name</b> and <b>Family Name</b>.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998632">Plant Name Authorities</a><font SIZE="2"> </font></h2>
+
+<p><font SIZE="2">It is not necessary to include the authorities of the species and
+infraspecific names in a HISPID3 transfer file. However, the inclusion of authorities with
+the botanical names prevents confusion between homonyms. If these authorities are
+required, then they can be included in the transfer file. To minimise variation in the
+citation of the names of authors, it is recommended that a published standard for the
+citation of authorities be used. One such standard is Brummitt, R.K. &amp; Powell, C.E.
+(1992) 'Authors of plant names' (Royal Botanic Gardens: Kew)(endorsed by the <i>International
+Working Group on Taxonomic Databases for Plant Sciences</i> - TDWG).<br>
+</font></p>
+
+<h2><a NAME="_Toc366998633">Other Comments</a> </h2>
+
+<p><font SIZE="2">Mixed collections are unacceptable and must be handled by duplicate
+records or, if the mixture is not significant, by a note in the <b>Name Comments</b>
+field. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917623">Suprafamilial Group </a>Name</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">supfam</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: CLASS (?) <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The relevant suprafamilial group name of the taxon
+referred to in the record. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS (supra generic category), ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid suprafamilial group name,
+with first letter in uppercase. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This field allows for material being sent for
+identification, particularly when even the family may not be known.<br>
+</font></p>
+
+<p><font SIZE="2">The ABIS standard included in this field any suprageneric category
+including family (see next field) and any other arbitrary grouping.<br>
+</font></p>
+
+<p><font SIZE="2">All plant groupings above the rank of genus are assigned automatically,
+the name depending on the classification system employed. As each institution uses its own
+classification system, in many cases different from others, this field and the next two
+fields may not always be a useful part of the interchange standard<b>. </b>However, it is
+simple to ignore this information when loading the data (if it is not required or is
+unsuitable), but it may be useful when reviewing the taxonomic system under which the data
+has been compiled when loading the file into a database. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917624">Family </a>Name</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">fam</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: FAMILY<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The family name appropriate to the Genus name field,
+entered in full. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS (supra generic category), ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid plant family name, with
+capitalisation of the first letter only. If the name of the plant family is unknown, then
+this field may contain the value UNKNOWN (in uppercase). In this case, the remaining name
+fields should <i>not</i> be filled. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: There is no universally accepted classification of
+plant genera into families, and several systems are in use in herbaria. Individual
+herbaria may choose to store two (or more) family fields to reflect different
+classification systems.<br>
+</font></p>
+
+<p><font SIZE="2">If institutions store family names or standard nomenclature in an
+abbreviated or encoded form, these <i>must</i> be expanded for transfer.<br>
+</font></p>
+
+<p><font SIZE="2">The ABIS standard includes this field in a suprageneric category (see
+previous field).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917625">Suprageneric Group</a> Rank</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">supgenrk</font> </h6>
+
+<p><font SIZE="2"><i>Description</i>: A field to indicate the rank of the suprageneric
+group name of the plant. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS (supra generic category)<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid suprageneric group rank,
+below the rank of family and above the rank of genus, capitalisation of the first letter
+only. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: See comments on conventions and necessity of this type
+of information under <b>Family Name</b> and<b> Suprafamilial Group Name</b> fields. <br>
+</font></p>
+
+<p><font SIZE="2">This field must contain the full name of the rank of the suprageneric
+group, eg. 'subfamily'. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917626">Suprageneric Group </a>Name</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">supgen</font> </h6>
+
+<p><font SIZE="2"><i>Description</i>: The suprageneric group name of the plant, entered in
+full.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS (supra generic category)<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid suprageneric group name,
+below the rank of family, capitalisation of the first letter only.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: See comments on conventions and necessity of this type
+of information under <b>Family Name</b> and<b> Suprafamilial Group Name</b> fields. <br>
+</font></p>
+
+<p><font SIZE="2">If the name of the genus of the plant is unknown, then this field does
+provide a higher level of identification than does the <b>Family Name</b> field alone. <br>
+</font></p>
+
+<hr>
+
+<h3><a NAME="_Toc366998634">HYBRIDS</a>, GRAFTS, CHIMAERA AND INTERGRADES<font SIZE="2"> </font></h3>
+
+<p><font SIZE="2">The interchange of hybrid formulae and intergrade names is particularly
+difficult in a flat�file format because the relational nature of these data cannot be
+readily maintained. Unlike ITF2 which has Hybrid Flag fields for intergeneric,
+interspecific and infraspecific hybrids and intergrades, HISPID3 has only one (namely, <b>Hybrid
+Flag</b> field, refer below). In HISPID3, the <b>Hybrid Flag</b> indicates the type of
+hybrid, grafts, chimaera or intergrade involved, but does not describe the rank to which
+it applies. If the name is a Latin or non-Latin collective name, or if the name is a graft
+or chimaera, then <i>only</i> the standard 'default' HISPID3 name fields are required in
+the transfer file. For example, the name <i>Lonicera </i>x<i> tellmaniana </i>would be
+tranferred with the letter 'x' in the <b>Hybrid Flag</b> field, 'Lonicera' in the <b>Genus
+Name</b> field, and 'tellmaniana' in the <b>Species Epithet</b> field.<br>
+</font></p>
+
+<p><font SIZE="2">The concept of 'parent 1' and 'parent 2' has been implemented in HISPID3
+to handle the transfer of names in the form of hybrid formulae and intergrades.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Example 1</i>: the intergeneric hybrid <i>Rhododendron</i> x <i>Vaccinium</i>
+would transferred with the letter 'H' in the <b>Hybrid Flag</b> field, 'Rhododendron' in
+the G<b>enus Name</b> field ('parent 1' - transfer code: <b>gen</b>) and 'Vaccinium' in
+the <b>Second Hybrid Genus Name</b> field ('parent 2' - transfer code: <b>genhy2</b>).
+That is:<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="64"><font SIZE="2">hyb </font></td>
+    <td WIDTH="124"><font SIZE="2">&quot;H&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="64"><font SIZE="2">gen </font></td>
+    <td WIDTH="124"><font SIZE="2">&quot;Rhododendron&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="64"><font SIZE="2">genhy2 </font></td>
+    <td WIDTH="124"><font SIZE="2">&quot;Vaccinium&quot;, </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Example 2</i>: the hybrid <i>Prostanthera cuneata</i> x <i>Prostanthera
+lasianthos </i>var. <i>subcoriacea</i> would be transferred with the letter 'H' in the <b>Hybrid
+Flag</b> field, 'Prostanthera' in the G<b>enus Name</b> field, 'cuneata' in the <b>Species
+Epithet</b> field ('parent 1' - transfer code <b>sp</b>), 'lasianthos' in the <b>Second
+Hybrid Species Epithet</b> field ('parent 2' - transfer code <b>sphy2</b>), 'var.' in the <b>Second
+Hybrid Infraspecific Rank Flag</b> ('parent 2' - transfer code <b>isprkhy2</b>), and
+'subcoriacea' in the <b>Second Hybrid Infraspecific Epithet</b> field ('parent 2' -
+transfer code: <b>isphy2</b>). In this example, hybrid formulae which describe the results
+of hybridisation at different ranks can be effectively interchanged. That is:<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="73"><font SIZE="2">hyb </font></td>
+    <td WIDTH="113"><font SIZE="2">&quot;H&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="73"><font SIZE="2">gen </font></td>
+    <td WIDTH="113"><font SIZE="2">&quot;Prostanthera&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="73"><font SIZE="2">sp </font></td>
+    <td WIDTH="113"><font SIZE="2">&quot;cuneata&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="73"><font SIZE="2">sphy2 </font></td>
+    <td WIDTH="113"><font SIZE="2">&quot;lasianthos&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="73"><font SIZE="2">isprkhy2 </font></td>
+    <td WIDTH="113"><font SIZE="2">&quot;var&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="73"><font SIZE="2">isphy2 </font></td>
+    <td WIDTH="113"><font SIZE="2">&quot;subcoriacea&quot;, </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Example 3</i>: the hybrid <i>Magnolia campbellii</i> subsp. <i>mollicomata</i>
+x <i>Magnolia sprengeri</i> var. <i>diva</i> would be transferred as:<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="71"><font SIZE="2">hyb </font></td>
+    <td WIDTH="106"><font SIZE="2">&quot;H&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="71"><font SIZE="2">gen </font></td>
+    <td WIDTH="106"><font SIZE="2">&quot;Magnolia&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="71"><font SIZE="2">sp </font></td>
+    <td WIDTH="106"><font SIZE="2">&quot;campbellii&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="71"><font SIZE="2">isprk </font></td>
+    <td WIDTH="106"><font SIZE="2">&quot;subsp.&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="71"><font SIZE="2">isp </font></td>
+    <td WIDTH="106"><font SIZE="2">&quot;mollicomata&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="71"><font SIZE="2">sphy2 </font></td>
+    <td WIDTH="106"><font SIZE="2">&quot;sprengeri&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="71"><font SIZE="2">isprkhy2 </font></td>
+    <td WIDTH="106"><font SIZE="2">&quot;var.&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="71"><font SIZE="2">isphy2 </font></td>
+    <td WIDTH="106"><font SIZE="2">&quot;diva&quot;, </font></td>
+  </tr>
+</table>
+</center></div>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917628">Hybrid </a>Flag</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">hyb <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: A field to indicate whether the plant name refers to
+a hybrid, graft chimaera or intergrade, without reference to rank.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF, MFN, Bisby (1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: If the accession is a hybrid, graft chimaera
+or intergrade, then the Hybrid field must consist of one of the characters in the table
+below:</font> </p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="111"><i><font SIZE="2">Values in Field </font></i></td>
+    <td WIDTH="246"><i><font SIZE="2">Nature of name in <i><b>Genus Name</b> field</i></font></i>
+    </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">x </font></td>
+    <td WIDTH="246"><font SIZE="2">A Latin collective name for a hybrid</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">G </font></td>
+    <td WIDTH="246"><font SIZE="2">A non-Latin collective name for a hybrid</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">H </font></td>
+    <td WIDTH="246"><font SIZE="2">A hybrid formula for a hybrid</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">+ </font></td>
+    <td WIDTH="246"><font SIZE="2">A graft hybrid or graft chimaera</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">� </font></td>
+    <td WIDTH="246"><font SIZE="2">An intergrade of non-hybrid nature</font> </td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Comments</i>:</font> </p>
+
+<p><font SIZE="2">1. The rules associated with these values are outlined under <b>Genus
+Name</b> field.</font> </p>
+
+<p><font SIZE="2">2. For interchange and data storage purposes, the value in this field
+for a hybrid is a lowercase 'x' not a multiplication sign (as specified in the
+International Code of Botanical Nomenclature), since the multiplication sign does not
+occur in the ASCII character set.</font> </p>
+
+<p><font SIZE="2">3. If an 'x' is placed in this field, then the plant name must be
+validly published under the ICBN.</font> </p>
+
+<p><font SIZE="2">Notes: ITF includes the letter '<b>U' </b>in the<b> '</b>Infraspecific
+Hybrid Flag' (refer ITF2) to indicate a Cultivar group name. However, HISPID3 only uses
+the <b>Cultivar Group Name</b> field (refer below) to transfer these data.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917629">Genus </a>Name</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">gen</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: GENUS<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The name of the genus of a plant or ,if part of a
+hybrid formula or intergrade, then the name of the first 'parent' of that formula or
+intergrade, entered in full.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF, MFN, Bisby (1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid genus name, capitalisation
+of the first letter only. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This field, combined with the following <b>Species
+Epithet</b> and <b>Infraspecies Epithet</b> fields, constitute the minimum taxonomic
+information for the identity of the specimen.<br>
+</font></p>
+
+<p><font SIZE="2">This field may contain an embedded hyphen, in which case the second word
+is in lowercase <br>
+</font></p>
+
+<p><font SIZE="2">1. This field <i>must</i> contain one of the following:</font> </p>
+
+<p><font SIZE="2">1.1 A validly published generic name under the ICBN or a manuscript
+name.<br>
+</font></p>
+
+<p><font SIZE="2">If the <b>Hybrid Flag field is </b><i>not</i> filled (not transferred),
+then this field must contain:</font> </p>
+
+<p><font SIZE="2">1.1.2 A non�hybrid name, validly published under the ICBN or a
+manuscript name.<br>
+</font></p>
+
+<p><font SIZE="2">If the name of the genus of the plant is unknown, then:</font> </p>
+
+<p><font SIZE="2">1.1.3 This field should not be filled. In this case, the remaining name
+fields should also not be filled.<br>
+</font></p>
+
+<p><font SIZE="2">If the <b>Hybrid Flag</b> is H and the name is an intergeneric hybrid
+name, then:</font> </p>
+
+<p><font SIZE="2">1.1.4 This field must contain the first 'parent' of a hybrid formula for
+an intergeneric hybrid name, validly published under the ICBN, eg. 'Rhododendron' for the
+hybrid formula <i>Rhododendron</i> x <i>Vaccinium<br>
+</i></font></p>
+
+<p><font SIZE="2">If the <b>Hybrid Flag</b> is x and the name is an intergeneric hybrid
+name, then:</font> </p>
+
+<p><font SIZE="2">1.1.5 This field must contain an intergeneric hybrid name, validly
+published under the ICBN, eg. Halimiocistus for x <i>Halimiocistus sahucii.<br>
+</i></font></p>
+
+<p><font SIZE="2">If the <b>Hybrid Flag</b> is + and the name is an intergeneric graft
+hybrid or graft chimaera, then:</font> </p>
+
+<p><font SIZE="2">1.1.6 This field must be the name of an intergeneric graft hybrid or
+graft chimaera, validly published under the Cultivated Code, eg. Crataegomespilus for + <i>Crataegomespilus
+dardarii. <br>
+</i></font></p>
+
+<p><font SIZE="2">If the <b>Hybrid Flag</b> is - and the name is an intergeneric
+intergrade, then</font> </p>
+
+<p><font SIZE="2">1.1.7 This field must contain the name of the first 'parent' of the
+intergrade.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917630">Second Hybrid Genus</a> Name</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">genhy2</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: GENUS<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The second name of a hybrid formula or intergrade
+between two plant genera, entered in full.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid genus name, capitalisation
+of the first letter only. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Refer discussion under <b>HYBRIDS, GRAFTS, CHIMAERA AND
+INTERGRADES</b> and compare with <b>Genus Name</b> field, above.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917631">Subgeneric Group </a>Name</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">subgen <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description: </i>The subgeneric group name of the plant, preceded by
+its rank, entered in full<i>. <br>
+</i></font></p>
+
+<p><font SIZE="2"><i>Relevant standards: </i>ITF <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>:<i> </i>Alpha; any valid subgeneric group
+name, capitalisation of the first letter only<i>.<br>
+</i></font></p>
+
+<p><font SIZE="2"><i>Comments</i>:</font> </p>
+
+<p><font SIZE="2">1. The subgeneric group name must be a single word.</font> </p>
+
+<p><font SIZE="2">2. The first letter must be in uppercase (A�Z), the rest of the word in
+lowercase letters (a�z).</font> </p>
+
+<p><font SIZE="2">3. One or two hyphens are permitted in the word; no characters other
+than the letters outlined above are permitted. </font></p>
+
+<p><font SIZE="2">This field must contain a validly published subgeneric group name under
+the ICBN.<br>
+</font></p>
+
+<p><font SIZE="2">This field must also contain one of the following abbreviations of the
+rank of the Subgeneric Group name:<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="111"><font SIZE="2"><i>Abbreviation</i> </font></td>
+    <td WIDTH="180"><i><font SIZE="2">Full subgeneric group name</font></i> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">subgen. </font></td>
+    <td WIDTH="180"><font SIZE="2">Subgenus</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">sect. </font></td>
+    <td WIDTH="180"><font SIZE="2">Section</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">subsect. </font></td>
+    <td WIDTH="180"><font SIZE="2">Subsection </font></td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">ser. </font></td>
+    <td WIDTH="180"><font SIZE="2">Series</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">subser. </font></td>
+    <td WIDTH="180"><font SIZE="2">Subseries</font> </td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2">If the name of the genus of the plant is unknown, then this field <i>must
+not</i> be filled. In this case, the remaining name fields should also be unfilled. <br>
+</font></p>
+
+<p><font SIZE="2">If the species name of the plant is unknown, then (if filled) this field
+does provide a higher level of identification than does the <b>Genus Name </b>field alone.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917632">Species </a>Qualifier</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">spql <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description:</i> This qualifier permits the <b>Species Epithet</b>
+field to be used for normal species names, as well as names of aggregate (refer <i>Comments</i>
+1, below) or segregate species.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF; Bisby (1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>:</font> </p>
+
+<p><font SIZE="2">1. If the Species Epithet field is <i>not </i>filled, then this field <i>must
+not</i> be filled.</font> </p>
+
+<p><font SIZE="2">2. If the <b>Hybrid Flag</b> is filled and the value in that field
+refers to an interspecific hybrid, then this field <i>must not</i> be<i> </i>filled.</font>
+</p>
+
+<p><font SIZE="2">Otherwise:</font> </p>
+
+<p><font SIZE="2">3. This field must consist of one of the values in the table below,
+which refers to the following situations in <b>Species Epithet</b> field:<br>
+</font></p>
+
+<p><font SIZE="2"><i>Content of field Nature of Name in</i><b> Species Epithet</b> field<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="92"><font SIZE="2">agg. </font></td>
+    <td WIDTH="205"><font SIZE="2">An aggregate species</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="92"><font SIZE="2">s. lat. </font></td>
+    <td WIDTH="205"><font SIZE="2">aggregate species (sensu lato)</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="92"><font SIZE="2">s. str. </font></td>
+    <td WIDTH="205"><font SIZE="2">segregate species (sensu stricto) </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Comments</i>:</font> </p>
+
+<p><font SIZE="2">1. If the entry is 'agg.', then the plant has been identified to an
+aggregate species, and not to any of the segregate microspecies within the aggregate.</font>
+</p>
+
+<p><font SIZE="2">2. If this field is filled, then Infraspecific Rank Flag and
+Infraspecific Epithet fields <i>must not</i> be filled.</font> </p>
+
+<p><font SIZE="2">3. The terms collective species or species groups are sometimes also
+used in plant names. They should be treated as for aggregate species.</font> </p>
+
+<p><font SIZE="2">4. Under the current standards, it is not possible to use the
+aggregate/segregate concept at levels other than the species level.</font> 
+
+<ol>
+  <li><font SIZE="2">This data type is quite distinct from the identification qualifier.<br>
+    </font></li>
+</ol>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917633">Species </a>Epithet</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">sp</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: SPEPITHET <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The species epithet of the plant or ,if part of a
+hybrid formula or intergrade, then the name of the first 'parent' of that formula or
+intergrade, entered in full.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF, TLR, MFN, Bisby (1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid species name, all
+lowercase, no embedded spaces. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: </font></p>
+
+<p><font SIZE="2">1. The specific epithet must be one word (except as in the cases of <i>Rules</i>
+1.1, 1.2, 3 and 4, below).</font> </p>
+
+<p><font SIZE="2">2. It must consist of lowercase letters (a�z), and may contain one or
+two hyphens. No other characters are permitted (except in the cases of <i>Rules</i> 1.1
+and 1.2).</font> </p>
+
+<p><font SIZE="2">3. The field may be left unfilled if the species epithet is unknown. It <i>must</i>
+be left unfilled if the Genus name is unknown (<b>Genus Name</b> field) or the <b>Family
+Name </b>field has the value UNKNOWN.</font> </p>
+
+<p><font SIZE="2">4. If the specific epithet of a plant is uncertain, then the following
+name fields should<i> not</i> be filled.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Rules</i>:</font> </p>
+
+<p><font SIZE="2">1. If the <b>Hybrid Flag is not filled, then this field must contain a
+validly published, non�hybrid specific epithet under the ICBN, except in the following
+special cases:</b></font> </p>
+
+<p><font SIZE="2">1.1 If the plant has not been identified to specific level, the field <i>must</i>
+be left unfilled, as must the following name fields. (The abbreviation sp. should not be
+entered in these circumstances.)</font> </p>
+
+<p><font SIZE="2">1.2 If the plant represents a new species which has not been formally
+described, then sp. nov., sp. A, sp. 1 (or other acceptable codes) should be entered, if
+possible followed by a unique identifier, such as the collector's name and number or the
+locality. The following <b>Species Author</b> field <i>must</i> be left unfilled.</font> </p>
+
+<p><font SIZE="2">2. If the <b>Hybrid Flag is x and it refers to an interspecific hybrid,
+then the entry in the field must be a Latin Collective name for an interspecific hybrid,
+eg. tellmaniana for </b><i>Lonicera </i>x<i> tellmaniana.</i></font> 
+
+<ol>
+  <li><font SIZE="2">If the <b>Hybrid Flag</b> is H<b> </b>and it refers to an interspecific
+    hybrid, then the entry in the field must be a Hybrid Formula, with the species epithet of
+    'parent 1' in this field and the species epithet of 'parent 2' transferred in <b>Second
+    Hybrid Species </b>Epithet field (transfer code: <b>sphy2</b>), eg. <i>Rhododendron
+    dichroanthum </i>x<i> griersonianum</i> is interchanged as follows:</font> </li>
+</ol>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="64"><font SIZE="2">hyb </font></td>
+    <td WIDTH="113"><font SIZE="2">&quot;H&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="64"><font SIZE="2">gen </font></td>
+    <td WIDTH="113"><font SIZE="2">&quot;Rhododendron&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="64"><font SIZE="2">sp </font></td>
+    <td WIDTH="113"><font SIZE="2">&quot;dichroanthum&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="64"><font SIZE="2">sphy2 </font></td>
+    <td WIDTH="113"><font SIZE="2">&quot;griersonianum&quot;, </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2">If only one parent is known, then enter the specific epithet of that
+parent alone (without the lower case letter 'x').</font> 
+
+<ol>
+  <li><font SIZE="2">If the <b>Hybrid Flag</b> is + and it refers to an interspecific hybrid,
+    then the entry in the field must be an Interspecific Graft Chimaera, eg. <i>Syringa </i>+<i>
+    correlata</i> is interchanged as follows:</font> </li>
+</ol>
+
+<p align="center"><br>
+<br>
+</p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="54"><font SIZE="2">hyb </font></td>
+    <td WIDTH="85"><font SIZE="2">&quot;+&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="54"><font SIZE="2">gen</font></td>
+    <td WIDTH="85"><font SIZE="2">&quot;Xyringa&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="54"><font SIZE="2">sp </font></td>
+    <td WIDTH="85"><font SIZE="2">&quot;correlata&quot;, </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2">5. If the <b>Species Qualifier</b> field is agg., then the entry in the
+field must be a validly published specific epithet under the ICBN, used for the name of
+the group of species concerned. The word agg. should <i>not </i>be included in the entry
+of this field.</font> </p>
+
+<p><font SIZE="2">The abbreviation sp. is not interchanged in HISPID3 if a plant has not
+been identified to the species epithet level (<i>Rule</i> 1.1, above).<br>
+</font></p>
+
+<p><font SIZE="2">For further information refer <i>Comments</i> under <b>Genus Name</b>
+Field.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917634">Second Hybrid </a>Species Epithet</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">sphy2</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: SPEPITHET <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The second specific epithet of a hybrid formula or
+intergrade between two plant species, entered in full.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid species name, all
+lowercase, no embedded spaces (refer <b>Species Epithet</b> field, above).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Refer discussion under <b>HYBRIDS, GRAFTS, CHIMAERA AND
+INTERGRADES</b> and <b>Species Epithet</b> field, above.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Notes</i>: The authority of the species names are not given when the
+name is a hybrid formula or intergrade.<br>
+<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917635">Species Author</a>FieldsSpecies Author</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">spau</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: SPAUTHOR <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The author citation of the species (as given in <b>Genus
+Name </b>and<b> Species Epithet</b> fields, above), in standard abbreviated form <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: TLR, MFN, Brummitt &amp; Powell (1992), Bisby
+(1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid author abbreviation,
+initials and first letter of surname in uppercase, and other characters as described
+below:</font> </p>
+
+<p><font SIZE="2">1. The full name of a species (as transferred in the<b> Species Epithet</b>
+field) must include this field.</font> </p>
+
+<p><font SIZE="2">2. This field is not filled for the full name of a species aggregate (as
+transferred in the<b> Species Qualifier</b> and <b>Species Epithet</b> fields)<i>.</i></font>
+</p>
+
+<p><font SIZE="2">3.<i> </i>Alphabetic letters (A-Z, a-z), fullstops (periods), pairs of
+brackets, apostrophes, hyphens, ampersands (&amp;) and spaces are all valid entries for
+this field.</font> </p>
+
+<p><font SIZE="2">4. For the citation of joint authors, it is recommended that the
+ampersand (&amp;) is used between the last two names, <i>not</i> 'et' or 'and'. If more
+than two authors, then a comma and space (, ) are used to separate all authors except for
+the last two.</font> </p>
+
+<p><font SIZE="2">5. Names in languages other than the English languages should be
+transliterated into the roman alphabet. However, if institutions are able to receive and
+send other alphabetic characters (eg. if using UNICODE), then these may be included in the
+transfer file.</font> </p>
+
+<p><font SIZE="2">6. Parenthetical author or authors in the recommended form enclosed in
+round brackets at the beginning of the field. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Since the author is unique to any accepted plant name,
+it is usually not essential for this information to be interchange.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Notes</i>: The authority of the species name is not given when the
+name refers to a hybrid formula or an intergrade. Therefore, the information transferred
+in this field <i>does not</i> refer to the <b>Second Hybrid Species Epithet</b> field.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917636">Infraspecific Rank </a>Flag</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">isprk</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: INFRARANK <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: A field to indicate the <i>lowest</i> infraspecific
+rank for the name in the <b>Infraspecific Epithet</b> field. The contents of this field
+are confined to the rank of the infraspecific name of non-collective, and non-cultivar
+group infraspecific taxa. It also indicates the <i>lowest</i> infraspecific rank for the
+name of the first 'parent' of a hybrid formula or intergrade. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF (in part), MFN, Bisby (1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; if the <b>Infraspecific Epithet</b>
+field is <i>filled </i>and the plant is<i> not</i> a Collective hybrid and is <i>not</i> a
+cultivar, then this field <i>must</i> be one of the values in the table below:<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="102"><i><font SIZE="2">Values in field </font></i></td>
+    <td WIDTH="369"><i><font SIZE="2">Rank of Name in Infraspecific Epithet field (Non-hybrid
+    names)</font></i> </td>
+  </tr>
+  <tr>
+    <td WIDTH="102"><font SIZE="2">subsp.</font></td>
+    <td WIDTH="369"><font SIZE="2">Subspecies</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="102"><font SIZE="2">var.</font></td>
+    <td WIDTH="369"><font SIZE="2">Variety</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="102"><font SIZE="2">subvar.</font></td>
+    <td WIDTH="369"><font SIZE="2">Subvariety</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="102"><font SIZE="2">f. </font></td>
+    <td WIDTH="369"><font SIZE="2">Form</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="102"><font SIZE="2">subf.</font></td>
+    <td WIDTH="369"><font SIZE="2">Subform</font> </td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Comments:</i> If the <b>Infraspecific Epithet</b> field is <i>not</i>
+filled, then this field <i>must not</i> be filled.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Notes</i>: The contents of this field represent the <i>lowest</i>
+infraspecific rank for this name.<br>
+</font></p>
+
+<p><font SIZE="2">ITF excludes the infraspecific rank of hybrids from this field.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Guidelines</i>:</font> </p>
+
+<p><font SIZE="2">Under the rules of the ICBN, every trinomial below the level of species
+is unique. Hence, <i>Rhododendron arboreum </i>subsp. <i>delavayi </i>var. <i>peramoemum </i>can
+be known uniquely as <i>Rhododendron arboreum </i>var. <i>peramoemum. </i>Therefore the
+name can consist of the genus, the species and the <i>lowest </i>infraspecific taxon name,
+qualified by its rank. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917637">Second Hybrid Infraspecific Rank </a>Flag</font>
+</h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">isprkhy2</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: INFRARANK <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: A field to indicate the <i>lowest</i> infraspecific
+rank for the name in the <b>Infraspecific Epithet</b> field of the second 'parent' of a
+hybrid formula or intergrade. The contents of this field are confined to the rank of the
+infraspecific name of non-collective, and non-cultivar group infraspecific taxa.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF (in part), MFN, Bisby (1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; if the <b>Infraspecific Epithet</b>
+field is <i>filled </i>and the plant is<i> not</i> a Collective hybrid and is <i>not</i> a
+cultivar, then this field <i>must</i> be one of the values in the table below:<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="102"><i><font SIZE="2">Values in field</font></i></td>
+    <td WIDTH="369"><i><font SIZE="2">Rank of Name in Infraspecific Epithet field (Non-hybrid
+    names)</font></i> </td>
+  </tr>
+  <tr>
+    <td WIDTH="102"><font SIZE="2">subsp.</font></td>
+    <td WIDTH="369"><font SIZE="2">Subspecies</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="102"><font SIZE="2">var.</font></td>
+    <td WIDTH="369"><font SIZE="2">Variety</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="102"><font SIZE="2">subvar.</font></td>
+    <td WIDTH="369"><font SIZE="2">Subvariety</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="102"><font SIZE="2">f.</font></td>
+    <td WIDTH="369"><font SIZE="2">Form</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="102"><font SIZE="2">subf.</font></td>
+    <td WIDTH="369"><font SIZE="2">Subform</font> </td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Comments:</i> Refer <b>Infraspecific Rank Flag</b> field (above) for
+further details.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Notes</i>: The transfer code (<b>isprkhy2</b>), as for other hybrid
+fields which are used to transfer information about the second 'parent' of the hybrid
+formula or intergrade conclude with 'hy2'. This should not be confused with <b>isp2rk </b>which
+is the transfer<b> </b>code for the <b>Second Infraspecific Rank Flag</b> and <b>isp2rkhy2</b>
+which is used to transfer the rank of the <b>Second Hybrid of the Second Lowest
+Infraspecific Epithet</b> when the full taxonomic name is being transferred.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917638">Infraspecific </a>Epithet</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">isp</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: INFRANAME <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The epithet of the <i>lowest</i> infraspecific rank
+of the name, entered in full.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF, TLR, MFN, Bisby (1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid infraspecific taxon
+epithet, all lower case. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>:</font> </p>
+
+<p><font SIZE="2">1. The entry must be one word (except as outlined in <i>Rules</i>,
+below).</font> </p>
+
+<p><font SIZE="2">2. It must only consist of lowercase letters (a�z), and may contain one
+or two hyphens. No other characters are allowed (except in the case of <i>Rules</i> 1.1,
+2, 4 and 5, below).</font> </p>
+
+<p><font SIZE="2">3. The field <i>may </i>be left unfilled to indicate that the plant is
+not identified below the species level. It <i>must not be filled</i> if the species
+epithet is not known. Indeterminate entries like 'subsp.', 'var.' etc., are <i>not</i>
+permissible. <br>
+</font></p>
+
+<p><font SIZE="2">See <i>Comments</i> under<b> Infraspecific Rank Flag </b>and <b>Species
+Epithet</b>. fields. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Rules</i>:</font> </p>
+
+<p><font SIZE="2">1. If the <b>Infraspecific Rank Flag</b> is subsp. var., subvar., f. or
+subf., then the entry must be an epithet in the rank denoted by that field, validly
+published under the ICBN, except in the following special case:</font> </p>
+
+<p><font SIZE="2">1.1 Where a new infraspecific taxon has not been formally described,
+subsp. nov., var. nov., subvar. nov., f. nov., or subf. nov. may be entered, if possible
+followed by a unique identifier, such as the collector's name and number or the locality</font>
+</p>
+
+<p><font SIZE="2">2. If the <b>Hybrid Flag value is 'H', then the entry must represent the
+first 'parent' in a hybrid formula</b></font> </p>
+
+<p><font SIZE="2">If the <b>Hybrid Flag</b> value is 'H' but only one 'parent' of a hybrid
+formula is known, then enter the infraspecific epithet of that parent alone</font> </p>
+
+<p><font SIZE="2">3. If the <b>Hybrid Flag</b> is 'x', then the entry must be a Latin
+collective name for an infraspecific hybrid. The name must be valid under the Cultivated
+Code.</font> </p>
+
+<p><font SIZE="2">4. If the <b>Hybrid Flag</b> value is G, then the entry must be a
+non-Latin collective name. It must be valid under the Cultivated Code.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Guidelines</i>:</font> </p>
+
+<p><font SIZE="2">Under the rules of the ICBN, every trinomial below the level of species
+is unique. Hence, <i>Rhododendron arboreum </i>subsp. <i>delavayi </i>var. <i>peramoemum </i>can
+be known uniquely as <i>Rhododendron arboreum </i>var. <i>peramoemum. </i>Therefore the
+name can consist of the genus, the species and the <i>lowest </i>infraspecific taxon name,
+qualified by its rank. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917639">Second Hybrid Infraspecific </a>Epithet</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">isphy2</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: INFRANAME <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The epithet of the <i>lowest</i> infraspecific rank
+of the name of the second 'parent' in a hybrid formula or intergrade, entered in full.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF, TLR, MFN, Bisby (1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid infraspecific taxon
+epithet, all lower case. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Refer the <b>Infraspecific Epithet</b> field for
+further details (above).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Notes</i>: The authority of the infraspecific names are not given
+when the name is a hybrid formula or intergrade.<br>
+<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917640">Infraspecific </a>Author</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">ispau</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: INFRAUTHOR <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description:</i> The author citation of the <i>lowest</i>
+infraspecific epithet, in standard abbreviated form.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF; Bisby (1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: See under <b>Species Author </b>field,
+above.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments: </i>See under <b>Species Author</b> field.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Notes</i>: The authority of the infraspecific names are not given
+when the name is a hybrid formula or intergrade.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917641">Second Infraspecific Rank </a>Flag</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">isp2rk <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description:</i> An additional field to indicate the rank of the <i>second
+lowest</i> infraspecific name (as given in the <b>Second Infraspecific Epithet</b> field),
+which is at a higher level to that of the <b>Infraspecific Epithet</b> field. This field
+is used when a 'full' taxonomic name is required (refer <i>Comments</i> and <i>Notes</i>,
+below). This field is also used when a 'full' taxonomic name is required for the first
+'parent' of a hybrid formula or intergrade.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF; Bisby (1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: See under <b>Infraspecific Rank Flag</b>,
+above. Note: these additional fields are for non-hybrid infraspecific taxa, <i>not</i> for
+hybrids, Collective names or cultivars.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>:<i> </i>This field has been included for those
+institutions who wish to transfer and/or receive a complete ('full') taxonomic name (as
+defined in <i>Notes</i>, below) in a form which is more easily inserted into a database
+than the contents of the <b>Full Name</b> field (p. 47). When more than one infraspecific
+name is being transferred, the following fields refer to the <i>lowest</i> level
+infraspecific name: <b>Infraspecific Rank Flag</b>, <b>Infraspecific Epithet</b>, and <b>Infraspecific
+Author</b>; whereas the <b>Second Infraspecific Rank Flag</b>, <b>Second Infraspecific
+Epithet</b>, and <b>Second Infraspecific Author </b>all refer to the<i> second lowest</i>
+level of infraspecific name (eg. var. and subsp., respectively). If institutions wish to
+transfer more than two levels of infraspecific names in this format, then the <i>third
+lowest</i> level has the number 3 included in the<i> Transfer Code</i> identifier (eg.
+isp3rk, isp3, isp3au), and so on, as appropriate.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Notes:</i> The 'full' scientific name includes the genus and species
+names, together with<i> all</i> infraspecific names and ranks (where relevant) and <i>all</i>
+appropriate authorities. Such 'full' names are extremely useful, especially if the
+complete taxonomic name of the taxon is required. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917642">Second Hybrid of the Second Infraspecific </a>Flag</font>
+</h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">isp2rkhy2 <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description:</i> An additional field to indicate the rank of the <i>second
+lowest</i> infraspecific name of the second 'parent' of a hybrid formula or intergrade (as
+given in the <b>Second Hybrid of the Second Infraspecific Epithet</b> field), which is at
+a higher level to that of the <b>Second Hybrid Infraspecific Epithet</b> field. This field
+is used when a 'full' taxonomic name is required. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF; Bisby (1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Refer <b>Second Infraspecific Rank Flag</b>,
+above.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Refer <b>Second Infraspecific Rank Flag</b>, above.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917643">Second Infraspecific </a>Epithet</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">isp2 <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: An additional field for the epithet of the <i>second
+lowest </i>infraspecific rank of the name of the plant, when a full taxonomic name is
+required (refer <i>Comments</i> under <b>Second Infraspecific Rank Flag</b> field, above).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF; Bisby (1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: See under <b>Infraspecific Epithet</b>
+field, above. Note: these additional fields are for non-hybrid infraspecific taxa, <i>not</i>
+for hybrids, collective names or cultivars.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>:<i> R</i>efer <i>Comments</i> under <b>Second
+Infraspecific Rank Flag</b> field, above.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917644">Second Hybrid of the Second Infraspecific </a>Epithet</font>
+</h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">isp2hy2 <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: An additional field for the epithet of the <i>second
+lowest </i>infraspecific rank of the name of the second 'parent' of a hybrid formula or
+intergrade, when a full taxonomic name is required.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF; Bisby (1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: See under <b>Infraspecific Epithet</b>
+field, above.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>:<i> R</i>efer <i>Comments</i> under <b>Second
+Infraspecific Rank Flag</b> field, above.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917645">Second Infraspecific </a>Author</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">isp2au <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description:</i> An additional field for the author citation of the <i>second
+lowest</i> infraspecific epithet, in standard abbreviated form.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF; Bisby (1994).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Refer under <b>Infraspecific Author</b> and<b> Second
+Infraspecific Rank Flag</b> fields, above. Note: these additional fields are for
+non-hybrid infraspecific taxa, <i>not</i> for hybrids, collective names or cultivars.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Notes</i>: The authority of the infraspecific names are not given
+when the name is a hybrid formula or intergrade.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917646">Vernacular </a>Names</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">vernam</font><font SIZE="2"> <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description:</i> A free text field to allow for the inclusion of
+vernacular (common) plant names.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Vernacular name followed by language of each
+name in round brackets ( ). <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments:</i> If more than one vernacular name, then each name (and
+language group) is separated by a comma and a space.<br>
+</font></p>
+
+<hr>
+
+<h3><a NAME="_Toc366998635">CULTIVATED PLANT NAMES</a><font SIZE="2"> </font></h3>
+
+<p><font SIZE="2">Rules for naming agricultural, forestry and horticultural plant have
+recently been revised in the <i>International Code of Nomenclature for Cultivated Plants</i>
+(Ed. P. Trehane, Quarterjack Publishing, 1995). Following the lead of ITF2, HISPID3 allows
+compatibility with this code by introducing two new fields, the <i>Cultivar Group Name</i>
+and the <i>Trade Designation Name</i>, in addition to the <i>Cultivar Name</i> field.
+These three fields allow for an accurate interchange of these plants, in accordance with
+the rules of the above code. The only names that may be used in this code are the Cultivar
+epithet, the Cultivar Group epithet, and the Trade Designation name (or other similar
+trade name).</font> </p>
+
+<p><font SIZE="2">Signs to indicate hybrids (x) or graft chimera (+) must NOT be used in
+any of the following three fields. Authors names are not required by the cultivated plant
+code, and should not be appended to the names given at any of the three ranks.</font> </p>
+
+<p><font SIZE="2">Examples (from ITF2), in HISPID3 transfer format:</font> </p>
+
+<p><font SIZE="2">1.<i> Brassica oleracea</i> Cauliflower Group</font> </p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="83"><font SIZE="2">gen </font></td>
+    <td WIDTH="104"><font SIZE="2">&quot;Brassica&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="83"><font SIZE="2">sp </font></td>
+    <td WIDTH="104"><font SIZE="2">&quot;oleracea&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="83"><font SIZE="2">culgnam </font></td>
+    <td WIDTH="104"><font SIZE="2">&quot;Cauliflower&quot;, </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2">2. <i>Dracaena fragrans</i> (Deremensis Group) 'Christianne'</font> </p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="83"><font SIZE="2">gen </font></td>
+    <td WIDTH="104"><font SIZE="2">&quot;Dracaena&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="83"><font SIZE="2">sp </font></td>
+    <td WIDTH="104"><font SIZE="2">&quot;oleracea&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="83"><font SIZE="2">culgnam </font></td>
+    <td WIDTH="104"><font SIZE="2">&quot;Deremensis&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="83"><font SIZE="2">culnam </font></td>
+    <td WIDTH="104"><font SIZE="2">&quot;Christianne&quot;, </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2">3.</font> </p>
+
+<p><font SIZE="2"><i>Salix matsudana</i> 'Tortuosa'</font> </p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="115"><font SIZE="2">gen </font></td>
+    <td WIDTH="95"><font SIZE="2">&quot;Salix &quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="115"><font SIZE="2">sp </font></td>
+    <td WIDTH="95"><font SIZE="2">&quot;matsudana&quot;,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="115"><font SIZE="2">culnam </font></td>
+    <td WIDTH="95"><font SIZE="2">&quot;Tortuosa&quot;, </font></td>
+  </tr>
+</table>
+</center></div>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917648">Cultivar Group </a>Name</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">culgnam <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The cultivar group name of a plant.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF; Trehane (1995)<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha</font> </p>
+
+<p><font SIZE="2">1. An entry in this field should consist solely of the cutivar group
+name.</font> </p>
+
+<p><font SIZE="2">2. If the accession cannot be assigned to a cultivar group, then the
+field should <i>not </i>be filled.</font> </p>
+
+<p><font SIZE="2"><i>Comments</i>:</font> </p>
+
+<p><font SIZE="2">1. The cultivar group name must be a valid cultivar group name under the
+International Code of Nomenclature for Cultivated Plants. This field should <i>not</i>
+contain a cultivar name or trade designation name.</font> </p>
+
+<p><font SIZE="2">2. The first letter of each word of the cultivar group name should be
+uppercase.</font> </p>
+
+<p><font SIZE="2">3. The word 'Group' should not be appended to the cultivar group name;
+this is redundant in this field for transfer, or for database storage ('Group' can easily
+be appended to the information contained in this field in output programs).</font> </p>
+
+<p><font SIZE="2">4. The cultivar group name should <i>not</i> be enclosed in parentheses
+(these can easily be added to the information contained in this field in output programs
+if required).(refer <b>CULTIVATED PLANT NAMES</b> example 2, below).<br>
+</font></p>
+
+<p><i><font SIZE="2">Guidelines: </font></i></p>
+
+<p><font SIZE="2">1. A cultivar group is an assemblage of similar, named cultivars within
+a genus or species (including hybrid genera and species), eg. <i>Lolium perenne</i> Early
+Group. Such groups are often associated with a cultivar name, and in this case the Group
+Name is normally enclosed by round brackets, eg. <i>Lolium perenne</i> (Early Group) cv.
+Devon Eaver. For further details, see Article 4 of the International Code of Nomenclature
+for Cultivated Plants.<br>
+</font></p>
+
+<p><font SIZE="2">2. Under the provisions of the International Code of Nomenclature for
+Cultivated Plants, cultivar group names are written in outputs as contained between round
+brackets <i>or</i> square brackets when a cultivar name or trade designation is given; if
+no cultivar or trade designation is given then these brackets are omitted. In outputs the
+word 'Group' always terminates the cultivar group name: eg. <i>Brassica oleracea</i>
+Cauliflower Group, <i>Dracaena fragrans</i> (Deremensis Group) 'Christianne' <i>or</i> <i>Dracaena
+fragrans</i> [Deremensis Group] 'Christianne'. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917649">Cultivar </a>Name</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">culnam <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The cultivar name of the plant represented by this
+record.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF; Trehane (1995)<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid cultivar name. The entry
+should consist solely of the cultivar name. The abbreviation 'cv.' should not be used
+(except under <i>Comments</i> 3 below), nor should the entry be enclosed in single quotes
+(these should be added in printed outputs only). <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>:</font> </p>
+
+<p><font SIZE="2">1. The cultivar must be a valid name published under the International
+Code of Nomenclature for Cultivated Plants.</font> </p>
+
+<p><font SIZE="2">2. Where the cultivar name directly follows the generic name, as in <i>Tulipa</i>
+'Apeldoorn', the fields between <b>Genus name</b> and this field should not be filled
+(namely, the fields from <b>Subgeneric group name</b> through to <b>Cultivar Group Name</b>).</font>
+</p>
+
+<p><font SIZE="2">3. If the record represents a cultivar of unknown name, then 'cv.'
+should be entered in this field. This appears to contradict the approach with species
+names, but in this case a blank, space or null does not imply that the taxon is an
+unidentified cultivar.<br>
+<br>
+</font></p>
+
+<p><font SIZE="2"><i>Guidelines</i>: </font></p>
+
+<p><font SIZE="2">1. A cultivar is part of the variation of cultivated plants being
+clearly distinguished by attributes that are distinct, uniform, stable and are retained
+when propagated by a suitable means. For further details, see Article 2 of the
+International Code of Nomenclature for Cultivated Plants.</font> </p>
+
+<p><font SIZE="2">2. Under the provisions of the International Code of Nomenclature for
+Cultivated Plants, cultivar names are written in outputs as contained between single
+quotes, eg. <i>Citrullus lanatus</i> 'Sugar Baby'. Double quotes or the abbreviation
+prefix 'cv. ' are <i>not</i> permitted under the Cultivated Plant Code.</font> </p>
+
+<p><font SIZE="2">3 The first character of each word in a cultivar name should be in
+uppercase (A-Z).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917650">Trade Designation </a>Name</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">tranam <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The trade name of an accession, where the taxon has
+a registered trade name or other similar trade designation.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF; Trehane (1995)<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>:</font> </p>
+
+<p><font SIZE="2">1. An entry in this field should consist solely of the trade designation
+name, if applicable.</font> </p>
+
+<p><font SIZE="2">2. If the accession does not bear a designated trade name, this field
+should not be filled. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: The trade name must be a valid name published under the
+International Code of Nomenclature for Cultivated Plants and accepted by the International
+Registration Authority for the group concerned. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Guidelines:</i> Trade names are used in place of or additional to a
+cultivar name when the accepted cultivar name is not considered suitable for marketing
+purposes.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917651">Full </a>Name</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">fulnam <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The full name of the plant, including full author
+citation, hybrid name, hybrid formula, collective name, cultivar name (as appropriate). <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Free text field. All previous rules, as
+described under the above name fields, apply in this field.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This field allows the full taxonomic name (including
+author citation), horticultural names, trade names and patents. Where there is more than
+one infraspecific rank (eg. quadrinomials or pentanomials), the reduction of this plant
+name to a trinomial (with only the lowest infraspecific rank cited) obscures much of the
+infraspecific hierarchy (refer discussion under RECORD IDENTIFICATION GROUP above).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917652">Name </a>Comments</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">namcom <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: Any comments about the name of the plant are
+transferred in this field.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Free text field.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Although mixed collections are unacceptable in HISPID3,
+this field can be used to refer to such collections when the mixture is not significant. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h3><a NAME="_Toc366998636">TYPIFICATION GROUP</a> </h3>
+
+<p><font SIZE="2">This group of fields conains three fields, <b>Type Qualifier</b>, <b>Type
+Status</b> and <b>Basionym</b>, which covers the typification of the name of the taxon as
+directly related to the accession record.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917654">Type Qualifier </a>Flag</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">tql <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: This field provides standard terms to qualify the
+identification of the type of the name of the record when doubts exist.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; as listed in the following table:</font>
+</p>
+<div align="center"><center>
+
+<table>
+  <tr>
+    <td WIDTH="121"><i><font SIZE="2">Values in Field</font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Possibly</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Probably</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">?</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Not </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Comments</i>: This field is used in conjunction with <b>Type Status</b>
+(below). If the <b>Type Status</b> field is <i>not</i> filled, then this field must <i>not</i>
+be used.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917655">Type </a>Status</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">tsta</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: TYPESTATUS <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: A code indicating the type status of the record.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: TLR <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; standard abbreviation, as listed in
+the following table: <br>
+</font></p>
+
+<p><i><font SIZE="2">Values in Field Meaning of Abbreviation<br>
+</font></i></p>
+<div align="center"><center>
+
+<table>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">EPI </font></td>
+    <td WIDTH="170"><font SIZE="2">epitype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">HOLO</font></td>
+    <td WIDTH="170"><font SIZE="2">holotype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">ISO </font></td>
+    <td WIDTH="170"><font SIZE="2">isotype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">ISOLECTO </font></td>
+    <td WIDTH="170"><font SIZE="2">isolectotype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">ISONEO </font></td>
+    <td WIDTH="170"><font SIZE="2">isoneotype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">ISOPARA </font></td>
+    <td WIDTH="170"><font SIZE="2">isoparatype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">ISOPARALECTO </font></td>
+    <td WIDTH="170"><font SIZE="2">isoparalectotype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">ISOSYN</font></td>
+    <td WIDTH="170"><font SIZE="2">isosyntype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">KLEPTO</font></td>
+    <td WIDTH="170"><font SIZE="2">kleptotype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">LECTO</font></td>
+    <td WIDTH="170"><font SIZE="2">lectotype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">NEO </font></td>
+    <td WIDTH="170"><font SIZE="2">neotype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">PARA</font></td>
+    <td WIDTH="170"><font SIZE="2">paratype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">PARALECTO</font></td>
+    <td WIDTH="170"><font SIZE="2">paralectotype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">SYN </font></td>
+    <td WIDTH="170"><font SIZE="2">syntype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">TOPO</font></td>
+    <td WIDTH="170"><font SIZE="2">topotype</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">TYPE</font></td>
+    <td WIDTH="170"><font SIZE="2">Unknown type material </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Comments</i>: This field is <i>not </i>to be filled if the record is<i>
+not</i> one of these kinds of type.<br>
+</font></p>
+
+<p><font SIZE="2">Although topotypes have no taxonomic or nomenclatural status, the
+category has been included for those who may wish to interchange this information.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917656"><font SIZE="2">Basionym</font></a> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">basnam <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The plant name (frequently the basionym) of which
+this specimen is a type, not necessarily the accepted name for the taxon.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: TLR <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; a valid plant name, including
+relevant rank identifiers (such as subsp., var.,) as required, conventional capitalisation
+of name and author.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Although a specimen may be the type of more than one
+basionym, this field <i>must</i> hold the most recent known name. When a specimen is the
+type of more than one basionym, then the following additional fields refer to the <i>second
+most recent</i> basionym, together with its type status: <b>Type Status of Second Most
+Recent Basionym</b> and <b>Second Most Recent Basionym </b>fields (Transfer codes: <b>tsta2</b>
+and <b>basnam2</b>, respectively). If more earlier basionyms are to be transferred, then
+the <i>third most recent</i> values are interchanged in the : <b>Type Status of Third Most
+Recent Basionym</b> and <b>Third Most Recent Basionym </b>fields (Transfer codes: <b>tsta3</b>
+and <b>basnam3</b>, respectively), and so on, as appropriate. The type qualifier field may
+be required to provide qualification to the identification of the types of the various
+earlier basionyms. These additional fields are briefly described below.<br>
+</font></p>
+
+<p><font SIZE="2">If the record is<i> not</i> a type, then this field must <i>not</i> be
+filled.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917657"><font SIZE="2">Second Most Recent Type Qualifier </font></a></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">tql2 <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: This field provides standard terms to qualify the
+identification of the type of the name of the <i>second most recent</i> basionym of the
+record when doubts exist.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; as listed in <b>Type Qualifier Flag</b>
+field (above). <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This field is used in conjunction with <b>Second Most
+Recent</b> <b>Type Status</b> field (below). If the <b>Second Most Recent</b> <b>Type
+Status</b> field is <i>not</i> filled, then this field must <i>not</i> be used.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917658">Second Most Recent Type Status</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">tsta2</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: TYPESTATUS <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: A code indicating the type status of the <i>second
+most recent</i> basionym of the record.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; standard abbreviation, as listed in <b>Type
+Status</b> field (above). <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: For further information refer to previous TYPIFICATION
+GROUP fields (above). <br>
+<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917659">Second Most Recent Basionym</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">basnam2 <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The <i>second most recent</i> basionym of which this
+specimen is a type, not necessarily the accepted name for the taxon.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; a valid plant name, including
+relevant rank identifiers (such as subsp., var.,) as required, conventional capitalisation
+of name and author.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: For further information refer to previous TYPIFICATION
+GROUP fields (above). <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917660">Third Most Recent Type Qualifier Flag</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">tql3 <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: This field provides standard terms to qualify the
+identification of the type of the name of the <i>third most recent</i> basionym of the
+record when doubts exist.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; as listed in <b>Type Status</b> field
+(above).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This field is used in conjunction with <b>Third Most
+Recent</b> <b>Type Status</b> field (below). If the <b>Third Most Recent</b> <b>Type
+Status</b> field is <i>not</i> filled, then this field must <i>not</i> be used.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917661">Third Most Recent Type Status</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">tsta3</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: TYPESTATUS <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: A code indicating the type status of the <i>third
+most recent</i> basionym of the record.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; standard abbreviation, as listed in <b>Type
+Status</b> field (above). <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: For further information refer to previous TYPIFICATION
+GROUP fields (above). <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917662">Third Most Recent Basionym</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">basnam3 <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The <i>third most recent</i> basionym of which this
+specimen is a type, not necessarily the accepted name for the taxon.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; a valid plant name, including
+relevant rank identifiers (such as subsp., var.,) as required, conventional capitalisation
+of name and author.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: For further information refer to previous TYPIFICATION
+GROUP fields (above). <br>
+</font></p>
+
+<p><font SIZE="2"><i>Notes</i>: If additional TYPIFICATION GROUP fields are required for
+fourth, fifth, etc. basionyms and types, then they should be transferred in the same
+format as the previous fields.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h3><a NAME="_Toc366998637">VERIFICATION GROUP</a><br>
+</h3>
+
+<p><font SIZE="2">This group of fields indicates the degree of confidence that can be
+placed in the identification of a record.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998638">Identification Qualifiers</a> <br>
+</h2>
+
+<p><font SIZE="2">The following comments on 'Identification Qualifiers' are relevant to
+the HISPID3 fields <b>Identification Qualifier</b> and <b>Rank Qualified Flag</b>. <br>
+</font></p>
+
+<p><font SIZE="2">The degree of uncertainty of identification may be indicated by adding
+various terms, such as '?', 'cf.' and 'aff.', to the name of a plant. The qualifying term
+applies to the part of the name that immediately <i>follows </i>the qualifier, and they
+can be placed in front of any element of the name. In a HISPID3 transfer file, taxa
+qualified in this way are treated as positively identified only to the level one above the
+rank qualified, for example, a record of <i>Cypripedium </i>aff. <i>candidum is </i>treated
+not as a valid record of the threatened plant <i>Cypripedium candidum </i>but only as a
+record for the genus <i>Cypripedium</i> that requires further checking to confirm whether
+the plant is really <i>C.</i> <i>candidum</i> or another species.<br>
+</font></p>
+
+<p><font SIZE="2">With infraspecific taxa and cultivars, no distinction is made between
+whether the term (eg. 'aff.') is added before the rank of the qualified part of the name
+or after it. In other words, the <i>Prunus maritima </i>aff. var. <i>gravesii </i>and <i>Prunus
+maritima </i>var. aff. <i>gravesii </i>are regarded as referring to the same taxon.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917665">Verification Level Flag</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">vlev <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The level to which the identification of the record
+has been verified. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; the entry must be one of the values
+in the table below: <br>
+</font></p>
+
+<table>
+  <tr>
+    <td WIDTH="121"><i><font SIZE="2">Values in Field </font></i></td>
+    <td WIDTH="539"><i><font SIZE="2">Meaning </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">0 (zero) </font></td>
+    <td WIDTH="539"><font SIZE="2">The name of the record has not been checked by any
+    authority</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">1 </font></td>
+    <td WIDTH="539"><font SIZE="2">The name of the record determined by comparison with other
+    named plants</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">2 </font></td>
+    <td WIDTH="539"><font SIZE="2">The name of the record determined by a taxonomist or by
+    other competent persons using herbarium and/or library and/or documented living material</font>
+    </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">3 </font></td>
+    <td WIDTH="539"><font SIZE="2">The name of the plant determined by taxonomist engaged in
+    systematic revision of the group</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">4 </font></td>
+    <td WIDTH="539"><font SIZE="2">The record is part of type gathering or propagated from
+    type material by asexual methods </font></td>
+  </tr>
+</table>
+
+<p><font SIZE="2"><i>Comments</i>: If it is not known whether the name of the record has
+been verified by an authority, then this field must <i>not</i> be filled.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917666">Verifier's Name</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">vnam <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The name of the person or persons who verified the
+identification of the plant, as qualified in the <b>Verification Level</b> field (above).
+Their institutional affiliation may be cited, too.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values:</i> Alpha; the full name of the verifier(s).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: If it is not known whether the name of the record has
+been verified (that is, the <b>Verification Level</b> field has not been filled), then
+this field must <i>not</i> be filled.</font> </p>
+
+<p><font SIZE="2">1. The verifier's family name (surname; with initial letter uppercase)
+followed by comma and space (, ) then initials of given names (in uppercase and each
+followed by a full stop, without spaces). Titles should be omitted.</font> </p>
+
+<p><font SIZE="2">2. If two names are needed, the names (formatted as in point 1 above)
+are separated by a comma and a space. If several names are needed, then the first name (as
+formatted in point 1 above) may be followed by 'et al.'</font> </p>
+
+<p><font SIZE="2">3. The verifier's institution may also be cited (as a code) in round
+brackets.</font> </p>
+
+<p><font SIZE="2"><i>Notes</i>: If necessary, the first and or other given names should be
+spelt out when there is a known chance of confusion. For example, to distinguish between
+Wilson, Paul G. and Wilson, Peter G. (with a space after the given name; no punctuation,
+except as separator between two names - refer point 2 above).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917667">Verification Date</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">vdat <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description: </i>The date on which the name of the plant was
+verified.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values: </i>Integer; year (4 digits) followed by month
+(2 digits) and the day (2 digits), without spaces between them.<br>
+</font></p>
+
+<table>
+  <tr>
+    <td WIDTH="92"><font SIZE="2">1. </font></td>
+    <td WIDTH="576"><font SIZE="2">In this notation, leading zeroes must be included for
+    months and days, ie. March is coded as '03' not '3' and the 6th day is coded as '06' not
+    '6'.</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="92"><font SIZE="2">Example:</font></td>
+    <td WIDTH="576"></td>
+  </tr>
+  <tr>
+    <td WIDTH="92"><font SIZE="2">19741008 </font></td>
+    <td WIDTH="576"><font SIZE="2">8 October 1974</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="92"><font SIZE="2">19120209 </font></td>
+    <td WIDTH="576"><font SIZE="2">9 February 1912</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="92"><font SIZE="2">2.</font></td>
+    <td WIDTH="576"><font SIZE="2">If the day of the month is not known, the last two digits
+    should be omitted.</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="92"><font SIZE="2">Example: </font></td>
+    <td WIDTH="576"><font SIZE="2">April 1881 would preferably be transferred as 188104.</font>
+    </td>
+  </tr>
+  <tr>
+    <td WIDTH="92"><font SIZE="2">3. </font></td>
+    <td WIDTH="576"><font SIZE="2">If the day and the month are not known, the last four
+    digits should be omitted and just the 4 digits of the year information interchanged.</font>
+    </td>
+  </tr>
+</table>
+
+<p><font SIZE="2"><i>Guidelines</i>: The HISPID3 transfers the year as a full 4-digit
+number to facilitate the use of the system in the next century, as well as to track
+verifications from the previous century.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917668">Text Verification Date</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">texvdat <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description: </i>The date on which the name of the plant was verified
+when the date is not in a form which satisfies the international date data format (as
+required in <b>Verification Date</b> field, above).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values: </i>Alpha; free text.</font> </p>
+
+<p><font SIZE="2"><i>Comments</i>: This field will probably not be used very frequently,
+but it may be useful when the verification date on a determinavit slip is not completely
+legible. For example, the day and month may be decipherable, but not the year. Therefore,
+the interpreted information can be transferred, even though not complete.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917669">Verification Literature</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">vlit <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: Citation of literature used for identification.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; free text field; cite each
+author, journal or book title, followed by volume, year and pages (as relevant); each
+component separated by comma and space.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Where multiple references are used, the most useful
+reference should be mentioned first, and each reference separated by semicolons ';'.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917670"><font SIZE="2">Verification History</font></a> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">vhist <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: Chronological listing of previous identifications,
+stating plant name, verifier, date, and reference.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; free text field.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This field would be a concatenation of information from
+previous <b>Family Name</b>, <b>Genus Names</b>, <b>Species Epithet</b>, <b>Species Author</b>,
+<b>Infraspecific Epithet</b>,<b> Infraspecific Author</b>, <b>Verifier's Name</b> and <b>Verification
+Date</b> fields for this record. <br>
+</font></p>
+
+<p><font SIZE="2">Some institutions may choose to keep: <br>
+</font>
+
+<ul>
+  <li><font SIZE="2">the last few identifications;</font> </li>
+  <li><font SIZE="2">the complete identification history; </font></li>
+  <li><font SIZE="2">just the prior name.</font> <br>
+  </li>
+</ul>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917671">Determinavit</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">det <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: A field to indicate the nature of the taxonomic
+verification<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; the entry must be one of the values
+in the table below: <br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="121"><i><font SIZE="2">Values in Field </font></i></td>
+    <td WIDTH="104"><i><font SIZE="2">Meaning </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">conf. </font></td>
+    <td WIDTH="104"><font SIZE="2">confirmavit</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">cit. </font></td>
+    <td WIDTH="104"><font SIZE="2">citavit</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">det. </font></td>
+    <td WIDTH="104"><font SIZE="2">determinavit</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">scrips. </font></td>
+    <td WIDTH="104"><font SIZE="2">scripsit</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">vid. </font></td>
+    <td WIDTH="104"><font SIZE="2">vidit</font> </td>
+  </tr>
+</table>
+</center></div>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917672">Rank Qualified Flag</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">rkql <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The rank of the <i>lowest </i>name/epithet of the
+taxon qualified by the entry in <b>Identification Qualifier</b> field (see below).</font> </p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF</font> </p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: If the <b>Identification Qualifier</b> field
+is filled, then the entry in this field <i>must</i> be one of the values in the table
+below:</font> </p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="121"><i><font SIZE="2">Values in Field</font></i></td>
+    <td WIDTH="189"><i><font SIZE="2">Rank qualified </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">B </font></td>
+    <td WIDTH="189"><font SIZE="2">Below Family</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">F </font></td>
+    <td WIDTH="189"><font SIZE="2">Family</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">G </font></td>
+    <td WIDTH="189"><font SIZE="2">Genus </font></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">S </font></td>
+    <td WIDTH="189"><font SIZE="2">Species </font></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">I </font></td>
+    <td WIDTH="189"><font SIZE="2">first Infraspecific Epithet </font></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">J </font></td>
+    <td WIDTH="189"><font SIZE="2">second Infraspecific Epithet</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">C </font></td>
+    <td WIDTH="189"><font SIZE="2">Cultivar </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Comments</i>: In each of these cases, the entry in the field that is
+qualified (eg. Species, Cultivar) <i>must</i> be filled.<br>
+</font></p>
+
+<p><font SIZE="2">If the <b>Identification Qualifier</b> Field is <i>not</i> filled, then
+this field <i>must not</i> be filled. That is, this field should only be used for plants
+not confidently and/or fully determined.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917673">Identification Qualifier</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">idql <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: A standard term to qualify the identification of the
+taxon when doubts have arisen while comparing the plant and the plant- description; refer
+introductory note under <b>CULTIVATED PLANT NAME (</b>above) and previous field.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: If the identification does not require
+qualification, then this field must not be filled.<br>
+</font></p>
+
+<p><font SIZE="2">If there is any doubt about the identification of the plant record, then
+this field must contain one of the following: <br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="149"><i><font SIZE="2">Conventional Notation </font></i></td>
+    <td WIDTH="151"><i><font SIZE="2">Meaning</font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">aff. </font></td>
+    <td WIDTH="151"><font SIZE="2">Akin to or bordering</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">cf. </font></td>
+    <td WIDTH="151"><font SIZE="2">Compare with</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">Incorrect </font></td>
+    <td WIDTH="151"><font SIZE="2">Incorrect</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">forsan </font></td>
+    <td WIDTH="151"><font SIZE="2">Perhaps</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">near </font></td>
+    <td WIDTH="151"><font SIZE="2">Close to</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="149"><font SIZE="2">? </font></td>
+    <td WIDTH="151"><font SIZE="2">Questionable</font> </td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2">The above meanings are taken from Stearn, W.T. (1972). 'Botanical Latin'
+(David &amp; Charles: Newton Abbot).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: <br>
+</font></p>
+
+<p><font SIZE="2">1. The 'Incorrect' coding has been introduced into HISPID3 to mark an
+identification where the name applied is known to be incorrect, but a new name has not yet
+been assigned. This field may be used when a loan and their electronic records are
+returned to the host institution to indicate that although the researcher excluded the
+specimen from one plant group, he/she was unable to provide a positive identification.</font>
+</p>
+
+<p><font SIZE="2">2. 'Forsan' and 'near' are frequently used historically.</font> </p>
+
+<p><font SIZE="2">3. &quot;Near' is an occasional alternative for 'cf.' and '?'.</font> </p>
+
+<p><font SIZE="2">4. At the generic level, the symbol '?' is normally the only
+identification qualifier used.</font> </p>
+
+<p><font SIZE="2">5. The symbol '?' is to be interpreted as 'possibly not' the correct
+name of the rank nominated in the Rank Qualified Flag field. The '?' clarifies which name
+or epithet is questioned (usually the lowest rank).</font> </p>
+
+<p><font SIZE="2">6. The '?' symbol is not to be used to express doubts concerning the
+lumping or splitting of certain taxa (refer <b>Species Qualifier </b>field, above). <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917674">Name Comments</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">namcom <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: A description of any further qualifications to the
+identity of the name of the record.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; free text.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h3><a NAME="_Toc366998639">LOCATION GROUP</a> <br>
+</h3>
+
+<p><font SIZE="2">This group of fields covers all the descriptive and coded spatial data
+that describes the geographic position that a plant was collected from, including
+supporting data such as altitude, depth (particularly for aquatic plants), and degree of
+precision in citing the locality details. <br>
+</font></p>
+
+<p><font SIZE="2">Where relevant, all of the standard HISPID3 fields in this group, the
+HABITAT GROUP, and the COLLECTION GROUP refer to the original wild source collection
+information. That is, the information recorded in all of these fields (eg. <b>Collection
+Date</b>, <b>Primary Collector's Name</b>, <b>Country of Origin</b>, <b>Habitat</b>, <b>Locality</b>,
+<b>Collection Notes</b>, <b>Primary Subdivision of Country of Origin</b>, <b>Secondary
+Subdivision of Country of Origin</b>, <b>Specific Geographic Unit</b>) refers to the
+original wild source collection.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998640">Subsequent Location Fields</a> <br>
+</h2>
+
+<p><font SIZE="2">If the current accession was taken from a secondary source (eg.
+cultivated material, of known or unknown wild source), then the relevant field identifiers
+would all be prefaced by the word 'Subsequent' and the relevant Transfer Codes would be
+prefaced by a lowercase 's'. For example, if an herbarium collection was taken from a
+cultivated collection growing in an Australian botanic garden which had been originally
+grown from seeds collected in the 'wild' from South Africa, then the <b>Country</b> field
+value would be 'South Africa' (with Transfer code: <b>cou), whereas the Subsequent Country
+</b>field (Transfer code: <b>scou) would be 'Australia'. Likewise, the field which
+contains the information about the collector's name of the current accession which was
+taken from cultivated material would be known as Subsequent Collector's Name</b> and the
+Transfer code would be <b>scnam</b>. The same 'Domain/Range/Values' apply as for the
+relevant 'primary' data fields.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Note</i>: these 'subsequent fields have not be further described in
+HISPID3, but they should be applied when required.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998641">Geocode Information</a> </h2>
+
+<p><font SIZE="2">The geocode information of the 'Place of Origin' data are held in a
+hierarchy of 4 levels. These are:<br>
+</font></p>
+
+<table>
+  <tr>
+    <td WIDTH="54"><font SIZE="2">1. </font></td>
+    <td WIDTH="37"><font SIZE="2">a.</font> </td>
+    <td WIDTH="499"><font SIZE="2">Political country (written in full), strictly following the
+    ISO system;</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="54"></td>
+    <td WIDTH="37"><font SIZE="2">b.</font> </td>
+    <td WIDTH="499"><font SIZE="2">Political country (codified), according to the ISO system;</font>
+    </td>
+  </tr>
+  <tr>
+    <td WIDTH="54"><font SIZE="2">2. </font></td>
+    <td COLSPAN="2" WIDTH="536"><font SIZE="2">Basic Recording Unit of the<b> </b>World
+    Geographical Scheme;</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="54"><font SIZE="2">3. </font></td>
+    <td COLSPAN="2" WIDTH="536"><font SIZE="2">A defined subdivision of the ISO unit;</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="54"></td>
+    <td WIDTH="37"><font SIZE="2">a.</font> </td>
+    <td WIDTH="499"><font SIZE="2">Primary subdivision of Country of Origin;</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="54"></td>
+    <td WIDTH="37"><font SIZE="2">b.</font> </td>
+    <td WIDTH="499"><font SIZE="2">Secondary subdivison of Country of Origin;</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="54"><font SIZE="2">4. </font></td>
+    <td COLSPAN="2" WIDTH="536"><font SIZE="2">The locality;</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="54"></td>
+    <td WIDTH="37"><font SIZE="2">a.</font> </td>
+    <td WIDTH="499"><font SIZE="2">Locality in text format;</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="54"></td>
+    <td WIDTH="37"><font SIZE="2">b.</font></td>
+    <td WIDTH="499"><font SIZE="2">Special Geographical Unit. </font></td>
+  </tr>
+</table>
+
+<p><font SIZE="2">The information relates to the place where the plant was collected, <i>not</i>
+to the full distributional range of the taxon.<br>
+</font></p>
+
+<h2><a NAME="_Toc366998642">Spatial Data Interchange</a><font SIZE="2"> <br>
+</font></h2>
+
+<p><font SIZE="2">The spatial data interchange standard followed by HISPID3 is based on
+the<i> Spatial Data Transfer Standard</i> (SDTS). The use of this standard for data
+transfer is expected to become common place. It has been accepted as a USA <i>Federal
+Information Processing Standard</i> (FIPS) and as an Australian standard by <i>Standards
+Australia Committee IT/4</i>. The Australia, New Zealand Land Information Council (ANZLIC)
+has supported this choice by sponsorship of AUSDEC (<i>Australian Spatial Data Exchange
+Centre</i>) whose purpose is to faciliate the introduction and adoption of SDTS in
+Australia. AUSLIG (Australian Surveying and Land Information Group) have defined a profile
+subset of SDTS which is applicable to their own data type. Full text of the Australian
+SDTS standard is available from <i>AUSDEC</i> or from <i>Standards Australia</i>.<br>
+</font></p>
+
+<p><font SIZE="2">The interchange of the <b>horizontal</b> components of spatial data (eg.
+Latitudes/Longitudes, Grids) in HISPID3 must follow:<br>
+</font>
+
+<ul>
+  <li><font SIZE="2">the <b>I</b>nternational Earth Rotation Service <b>T</b>errestrial <b>R</b>eference
+    <b>F</b>rame (ITRF) or a derivative of it. For example, in Australia <b>MGA94</b> (Map
+    Grid of Australia) which is based on GDA94 (Geocentric Datum of Australia); in New Zealand
+    the NZMG (New Zealand Map Grid) should be used as the approved standard;</font> </li>
+  <li><font SIZE="2">the data of the approved grid system are <b>Integers</b> and are in <b>metres</b>;</font>
+  </li>
+  <li><font SIZE="2">the map grid projection must be cited, but it should normally be the UTM
+    (Universal Transverse Mercator);</font> </li>
+  <li><font SIZE="2">the <b>full</b> <b>6-digit</b> <b>Easting</b> and <b>7-digit</b> <b>Northing</b>
+    notation must be cited, prefaced by the appropriate hemisphere alphabetic indicator code
+    (Zones are not to be used);</font> </li>
+  <li><font SIZE="2">the precision (resolution) of the data are <b>Real</b> and are in <b>metres</b>.</font>
+  </li>
+</ul>
+
+<p><font SIZE="2"><i>Note</i>: MGA94 and WGS84 (World Geodetic System 1984 - as modified
+in 1994)(the reference frame used by GPS) are in agreement to within approximately 1
+metre. For specific details of requirements for map grid references in HISPID3 refer <b>Spatial
+Grid </b>fields (below).<br>
+</font></p>
+
+<p><font SIZE="2">The interchange of the <b>vertical</b> components of spatial data (eg.
+Altitude, Depth) in HISPID3 must follow: <br>
+</font>
+
+<ul>
+  <li><font SIZE="2">ITRF or a derivative of it. For example, in Australia the AHD71 geoidal
+    heights (Australian Height Datum 1971 - based on the mean sea level) are used rather than
+    the WGS84 ellipsoidal heights (as used by GPS);</font> </li>
+  <li><font SIZE="2">the data are <b>Real</b> and are in <b>metres</b>;</font> </li>
+  <li><font SIZE="2">the precision (resolution) of the data are <b>Real</b> and are in <b>metres</b>.</font>
+    <br>
+    <br>
+  </li>
+</ul>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917678">Country</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">cou</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: ISOCOUNTRY (?), BOTCOUNTRY, CONTINENT(?), REGION,
+ISOREGION, BASICRECU<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The name of the country or major region where the
+plant specimen was collected, entered in full.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF, TLR, WGSUB, ISO, Hollis &amp;
+Brummitt (1992)<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; accepted standard full political
+country name, uppercase. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: If the name of the country where the plant was
+collected is unknown, then this field should contain the value 'UNKNOWN' (in uppercase).
+In this case, the following <b>ISO Code for Country of Origin</b> field must have the
+entry 'XX' or 'XY'. All remaining 'location group' fields should be left unfilled.<br>
+</font></p>
+
+<p><font SIZE="2">It is recommended that the spelling of the country should be as
+recognised by the International Standards Organization (ISO).<br>
+</font></p>
+
+<p><font SIZE="2">It is recommended that new country names be enclosed in square brackets,
+after the old country name, where country names or boundaries have changed. The 2 letter
+ISO codes in <b>ISO Code for Country of Origin</b> field (refer below) assist the updating
+of countries where boundaries are changing. <br>
+</font></p>
+
+<p><font SIZE="2">Separate fields for state/province and country are needed to adequately
+handle the situation with international collections. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917679">ISO code for Country of Origin</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">iso <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The 2 letter code for the representation of the name
+of the country where the plant was collected, using the codes assigned by the
+International Standards Organization (ISO).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: The code must consist of 2 uppercase letters
+(A�Z).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>:</font> </p>
+
+<p><font SIZE="2">1. This field can only contain a valid entry as defined by the
+International Standards Organization (ISO Standard 3166).</font> </p>
+
+<p><font SIZE="2">2. Two other entries are permitted in addition to those defined by ISO:<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="130"><i><font SIZE="2">Values in Field </font></i></td>
+    <td WIDTH="170"><i><font SIZE="2">Meaning </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="130"><font SIZE="2">XX</font></td>
+    <td WIDTH="170"><font SIZE="2">Country unknown</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="130"><font SIZE="2">XY </font></td>
+    <td WIDTH="170"><font SIZE="2">Country not applicable </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Notes</i>: The 'XX' code should be used when no 'Country of Origin'
+information is provided. The 'XY' code should be used for non-specific collection
+localities, eg. Africa, South East Asia.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917680"><font SIZE="2">World Geographical Scheme</font></a> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">wgs <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: World Geographical Scheme for Recording Plant
+Distributions by S. Hollis and R.K. Brummitt. - Plant Taxonomic Database Standards No. 2,
+Version 1.0 (1992).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: The contents of this field must be a valid
+entry from the above publication.</font> </p>
+
+<p><font SIZE="2"><i>Comments</i>:</font> </p>
+
+<p><font SIZE="2">1. This code contains up to 5 characters when taken to the complete
+Level 4 Geographical Scheme. </font></p>
+
+<p><font SIZE="2">2. Every code is unique, so that the Level 1, 2 and 3 codes must also be
+recognised if the complete Level 4 code is not provided.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917681">Primary Subdivision of Country of Origin</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">pru <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The primary recording unit which is the highest
+order subdivision recognised by the <b>Country of Origin</b>.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF; Hollis &amp; Brummitt (1992) Complete
+4-level Geographical scheme (refer Table 4 in Hollis &amp; Brummitt, 1992).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; in full or standard abbreviation
+accepted by or agreeing with the Hollis &amp; Brummitt (1992) standard full Complete
+4-level Geographical area.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>:</font> </p>
+
+<p><font SIZE="2">1. The entry in the field should preferably be a valid entry as defined
+by Table 4 (Hollis &amp; Brummitt 1992).</font> </p>
+
+<p><font SIZE="2">2. If the entry is not part of the Hollis &amp; Brummitt (1992)
+standard, then it must be equivalent to the entries in this latter standard. For example,
+this field is expected to contain State, Province, and other comparable geographical
+regions.</font> </p>
+
+<p><font SIZE="2">3. The abbreviations used for this field may be based on the official
+(frequently political) abbreviations used within the <b>Country of Origin</b>, rather than
+those of Hollis &amp; Brummitt (1992) or the primary recording unit may be transferred in
+full.<br>
+<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917682">Secondary Subdivision of Country of Origin</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">sru <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The secondary recording unit which is the second
+highest-order subdivision of <b>Country of Origin</b> field.</font> </p>
+
+<p><font SIZE="2">TDWG Short name: BASICRECU (?), LOCALPOLU<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF, TLR, WGSUB<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; written in full or any valid regional
+code or abbreviation (and then in uppercase) as used by the relevant country or region <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This field contains the district or region from which
+the specimen was collected, usually a subdivision of State or Province.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917683"><font SIZE="2">Special Geographic Unit</font></a> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">sgu <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The special geographic recording unit describes
+specific conservation areas and other nature reserves of <b>Country of</b> <b>Origin</b>
+field. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant Standards</i>: ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values: </i>Alphanumeric; written in full.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: The field consists of the name of a defined
+conservation area, such as national or state parks, forest reserves, nature reserves,
+conservation or heritage parks.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917684">Locality</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">loc</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: LOCALITY, STANLOC (?)</font> </p>
+
+<p><font SIZE="2"><i>Description</i>: The locality where the plant was collected within
+the country and subdivisions assigned in the previous three fields.<br>
+</font></p>
+
+<p><font SIZE="2">Relevant standards: ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>:<i> </i>Alphanumeric; free text, plain
+language description of the locality, as on the specimen label.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Where the locality covers more than one country, eg.
+'Himalayas', and the Country Of Origin<b> </b>is unknown, an entry in the <b>Locality</b>
+field may be used in conjunction with the value 'XX' (in <b>ISO code for Country of Origin</b>
+field) and UNKNOWN (in the <b>Country of Origin</b> field).<br>
+<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917685">Altitude</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">alt</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: ELEVATIONL <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The altitude of the collection locality or if the
+collection has been made over an altitudinal range, then the <i>minimum</i> altitude of
+the collection locality (cf. <b>Maximum Altitude</b> field), in metres above or below sea
+level (cf. <b>Depth</b> field).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: SDTS, ITRF, AHD71, ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>:<i> </i>Real; any geographically reasonable
+altitude in metres.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Altitudes in feet must be converted to metres before
+data are interchanged. <br>
+</font></p>
+
+<p><font SIZE="2">Negative values indicate terrestrial altitudes below sea level
+(depressions), not aquatic environments or caves (refer <b>Depth</b> field below). A
+negative altitude must be preceded by a minus sign, without a space. The plus sign for
+positive altitudes should be omitted.<br>
+</font></p>
+
+<p><font SIZE="2">If the Altitude is unknown, then this field should not be filled.<br>
+<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917686"><font SIZE="2">Accuracy of Altitude</font></a> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">altacy</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: ELEVLACCUR <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The estimated accuracy of the altitude or, when a
+range of altitudes given, then the estimated accuracy of the minimum altitude, in metres. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: SDTS, ITRF, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>:<i> </i>Real; in metres. If degree of
+accuracy is unknown, then this field should not be filled.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Refer to <i>Comments</i>: of the <b>Altitude</b> field.<br>
+</font></p>
+
+<p><font SIZE="2">The two fields <b>Accuracy of Altitude</b> and <b>Accuracy of Maximum
+Altitude</b> (refer below) are given to record the accuracy of the altitude geocodes when
+a collection is made over an altitudinal range. The <b>Accuracy of Altitude</b> field
+refers to the accuracy of the value recorded for the lower <b>Altitude</b> field, and <b>Accuracy
+of Maximum Altitude</b> applies to the value in <b>Maximum Altitude</b> field. If the
+collection altitude only refers to one value, then only <b>Altitude</b> field and the <b>Accuracy
+of Altitude</b> should be filled.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Examples</i>: If a collection was made from several plants growing on
+a mountain side, then <b>Altitude</b> field refers to the lowest altitude, and <b>Maximum
+Altitude</b> field to the highest altitude. The collector may have a very accurate
+altitude reading for the lowest position, but only a coarse approximation for the upper
+range. Therefore the accuracy value in the <b>Accuracy of Altitude</b> field would be
+different from that recorded in the <b>Accuracy of Maximum Altitude</b> field. By filling
+out the two Altitude fields, the data receiver knows that the specimens were collected
+over a spectrum of plant material.<br>
+</font></p>
+
+<table>
+  <tr>
+    <td WIDTH="189"><font SIZE="2">Altitude</font></td>
+    <td WIDTH="57"><font SIZE="2">100</font> </td>
+    <td WIDTH="331"><font SIZE="2">Material collected from several plants with an accurate</font>
+    </td>
+  </tr>
+  <tr>
+    <td WIDTH="189"><font SIZE="2">Accuracy of Altitude</font></td>
+    <td WIDTH="57"><font SIZE="2">5</font></td>
+    <td WIDTH="331"><font SIZE="2">lower altitudinal reading, but with the upper altitudinal</font>
+    </td>
+  </tr>
+  <tr>
+    <td WIDTH="189"><font SIZE="2">Maximum Altitude</font></td>
+    <td WIDTH="57"><font SIZE="2">250</font> </td>
+    <td WIDTH="331"><font SIZE="2">limit anywhere between 225 and 275 metres.</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="189"><font SIZE="2">Accuracy of Maximum Altitude</font> </td>
+    <td WIDTH="57"><font SIZE="2">25</font></td>
+    <td WIDTH="331"></td>
+  </tr>
+</table>
+
+<p><font SIZE="2">Another example is when the collection was from only one plant source,
+for which there is an inaccurate altitude reading. <br>
+</font></p>
+
+<table>
+  <tr>
+    <td WIDTH="189"><font SIZE="2">Altitude</font></td>
+    <td WIDTH="57"><font SIZE="2">1000</font> </td>
+    <td WIDTH="331"><font SIZE="2">This plant was collected at an altitude anywhere</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="189"><font SIZE="2">Accuracy of Altitude</font></td>
+    <td WIDTH="57"><font SIZE="2">100</font></td>
+    <td WIDTH="331"><font SIZE="2">between 900 and 1100 metres.</font> </td>
+  </tr>
+</table>
+
+<p><font SIZE="2"><i>Note</i>: if the <b>Accuracy of Altitude</b> field is omitted, then
+it should be assumed that the level of accuracy is not known.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917687">Maximum Altitude</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">altx</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: ELEVATIONH <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The maximum altitude when the collection is cited as
+having been collected over an altitudinal range, in metres above or below sea level (cf. <b>Depth</b>
+field).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: SDTS, ITRF, AHD71, ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>:<i> </i>Real; any geographically reasonable
+altitude in metres.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Altitudes in feet should be converted to metres before
+data are interchange. Negative values indicate terrestrial altitudes below sea level
+(depressions), not aquatic environments or caves (refer <b>Depth</b> field below). A
+negative altitude must be preceded by a minus sign, without a space. The plus sign for
+positive altitudes should be omitted.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917688">Accuracy of Maximum Altitude</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">altacyx</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: ELEVHACCUR <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The estimated accuracy of the <i>maximum</i>
+altitude when the collection is cited as being taken from within an altitudinal range, in
+metres. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: SDTS, ITRF, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>:<i> </i>Real; in metres. If degree of
+accuracy is unknown, then this field should not be filled.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Refer to <i>Comments</i> of the <b>Altitude</b> field
+and Accuracy of Altitude field (above). <br>
+</font></p>
+
+<p><font SIZE="2"><i>Note</i>: If the <b>Accuracy of Altitude</b> and/or the <b>Accuracy
+of Maximum Altitude</b> fields are omitted, then it should be assumed that the level of
+accuracy is not known.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917689">Source of Altitude Accuracy Flag</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">altsou <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: Flag indicating the source of the altitude and
+precision calculations. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid entry as listed in the
+following table:<br>
+</font></p>
+
+<p><i><font SIZE="2">Values in Field<br>
+</font></i></p>
+
+<p><font SIZE="2">collector</font> </p>
+
+<p><font SIZE="2">compiler</font> </p>
+
+<p><font SIZE="2">automatically generated. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: The altitudes and altitude precisions provided by the
+plant collector are usually from GPS readings, maps on-site, extracted from the field book
+or from the herbarium label. Those provided by compilers other than the collector, are
+based on the locality stated in the field book or on the herbarium label. Automatically
+generated altitudes and altitude precisions are produced by various computer programs (eg.
+GIS, DEM).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917690"><font SIZE="2">Method of Altitude Determination</font></a> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">altdet <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: This field indicates how the altitude was derived.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid entry as listed in the
+following table:<br>
+</font></p>
+
+<p><font SIZE="2"><i>Values in Field</i> <i>Meaning <br>
+</i></font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Altimeter</font></td>
+    <td WIDTH="170"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">DEM</font></td>
+    <td WIDTH="170"><font SIZE="2">Digital Elevation Model</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">GPS </font></td>
+    <td WIDTH="170"><font SIZE="2">Global Positioning System</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Field Estimate</font></td>
+    <td WIDTH="170"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Map</font></td>
+    <td WIDTH="170"></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Unknown</font></td>
+    <td WIDTH="170"></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Comments</i>: Although this field may be coded in institutional
+databases, the full word or phrase should be used when interchanging data.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917691">Depth</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">dep <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The depth of the collection locality beneath the
+water surface or below the ground surface, in metres.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: SDTS, ITRF, AHD, ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values: </i>Real, any geographically reasonable depth,
+in metres<i>.<br>
+</i></font></p>
+
+<p><font SIZE="2"><i>Comments:</i> Depth in feet and fathoms must be converted to metres
+before transfer. <br>
+</font></p>
+
+<p><font SIZE="2">Depth below ground surface would be used to indicate the depth of a
+collection made from within a terrestrial cave. <br>
+</font></p>
+
+<p><font SIZE="2">As with the altitude fields (namely <b>Altitude </b>and<b> Maximum
+Altitude </b>fields), a duplicate field may be necessary to indicate a range of depths, or
+the accuracy of measurement; refer <b>Maximum Depth</b> and <b>Accuracy of Maximum</b> <b>Depth</b>
+(below).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917692">Accuracy of Depth</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">depacy <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The accuracy of the depth estimation, or when a
+range of depths are given, then the accuracy of the minimum depth estimation, in metres. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: SDTS, ITRF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>:<i> </i>Real; in metres. If degree of
+accuracy is unknown, then this field should not be filled.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: If the <b>Accuracy of Depth</b> field is omitted, then
+it should be assumed that the level of accuracy is not known.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917693">Maximum Depth</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">depx <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The maximum depth when the collection is cited as
+being taken from a range of depths, in metres beneath the water surface or below the
+ground surface.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: SDTS, ITRF, AHD, ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>:<i> </i>Real; any geographically reasonable
+depth in metres.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Depth in feet and fathoms should be converted to metres
+before transfer. <br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917694">Accuracy of Maximum Depth</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">depacyx <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The accuracy of the maximum depth estimation when
+the collection is cited as being taken from a range of depths, in metres.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: SDTS, ITRF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>:<i> </i>Real; in metres. If degree of
+accuracy is unknown, then this field should not be filled.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: If the <b>Accuracy of Depth</b> and/or the <b>Accuracy
+of Maximum Depth</b> fields are omitted, then it should be assumed that the level of
+accuracy is not known<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917695">Latitude, Degree</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">latdeg</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: LATDEGH, LATDEGH<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The degrees of latitude of the collection locality,
+as quoted from the herbarium label or derived.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF, AUSLIG Master Name File,
+Gazetteers<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values: </i>Integer; within the range 0 � 90, any valid
+and biogeographically meaningful latitude in degrees.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>:</font> </p>
+
+<p><font SIZE="2">1. If the latitude is not known, then this and the following latitude
+fields <i>mus</i>t be left unfilled.</font> </p>
+
+<p><font SIZE="2">3. If this field is filled, then the last latitude field (<b>Latitude,
+Direction</b>) <i>must </i>consist of one of the letters 'N' or 'S' (for North or South).</font>
+</p>
+
+<p><font SIZE="2">4. The geocode information <i>should</i> be interchanged as latitude and
+longitude in degrees, minutes, seconds and direction. Decimal degrees <i>must</i> be
+converted to degrees, minutes and seconds before the data are interchanged.</font> </p>
+
+<p><font SIZE="2">5. Grid references<i> should</i> be converted to degrees, minutes,
+seconds and direction before data are interchanged. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Notes</i>: The ABIS standard indicates a single 7�character field,
+the first two of which are degrees, the second two minutes, the third two seconds and last
+one direction. This standard is <i>not</i> followed in HISPID3. <br>
+</font></p>
+
+<p><font SIZE="2">To indicate a range of latitudes and longitudes, a duplicate set of
+latitude and longitude fields will be required. <br>
+</font></p>
+
+<p><font SIZE="2">When this field is selected, then the <b>Longitude</b> fields must be
+used, not the <b>Spatial Grid</b> fields.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917696">Latitude, </a>Minutes</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">latmin</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: LATMINH, LATMINL<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The minutes of latitude of the collection locality,
+as quoted from the label or derived.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; 0 � 59, any valid and
+biogeographically meaningful latitude in minutes.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: See Comment under <b>Latitude, Degrees</b>.<br>
+</font></p>
+
+<table>
+  <tr>
+    <td WIDTH="54"><font SIZE="2">1.</font></td>
+    <td WIDTH="576"><font SIZE="2">If the latitude degrees (<b>Latitude, Degrees</b> field) is
+    not known, then this and the following latitude fields <i>must </i>be left unfilled.</font>
+    </td>
+  </tr>
+  <tr>
+    <td WIDTH="54"><font SIZE="2">2.</font></td>
+    <td WIDTH="576"><font SIZE="2">If the latitude minutes (<b>Latitude, Minutes</b> field) is
+    not known, then this and latitude seconds (<b>Latitude, Seconds</b> Field)<i> must</i> be
+    left unfilled. </font></td>
+  </tr>
+</table>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917697">Latitude, </a>Seconds</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">latsec</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: LATSECH, LATSECL<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The seconds of latitude of the collection locality,
+as quoted from the label or derived.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2">Domain/Range/Values: Integer; 0 � 59, any valid and biogeographically
+meaningful latitude in seconds.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: See Comment under <b>Latitude, Degrees</b>.<br>
+</font></p>
+
+<p><font SIZE="2">If the value for this field is unknown, then this field <i>must</i> be
+left unfilled.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917698">Latitude, Direction</a> Flag</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">latdir</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: LATDIRHIGH, LATDIRLOW<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The abbreviated direction of latitude of the
+collection locality, relative to the equator, as quoted from the label or derived. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; N or S.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: See Comment under <b>Latitude, Degrees</b>.<br>
+</font></p>
+
+<p><font SIZE="2">If <b>Latitude, Degrees</b> field is filled, then this field<i> must</i>
+consist of one of the letters 'N' or 'S' (for North or South).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917699">Longitude, </a>Degrees</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">londeg</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: LONGDEGH, LONGDEGL<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The degrees of longitude of the collection locality,
+as quoted from the label or derived.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF, AUSLIG Master Name File,
+Gazetteers<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; 0 � 180, any valid and
+biogeographically meaningful longitude in degrees.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: <br>
+</font></p>
+
+<p><font SIZE="2">1. Exact location information for rare and/or endangered plants can be
+omitted from the transfer record by not transferring the seconds from the <b>Latitude,
+Seconds</b> and <b>Longitude, Seconds</b> fields for latitude and longitude, respectively<i>
+or</i>, for more conservationally sensitive plants, the data in the <b>Latitude, Minutes</b>
+and <b>Longitude, Minutes</b> fields need not be transferred.</font> </p>
+
+<p><font SIZE="2">2. If the longitude is not known, then this and the following longitude
+fields<i> must</i> be left unfilled.</font> </p>
+
+<p><font SIZE="2">3. If this field is filled, then the last longitude field (<b>Longitude,
+Direction</b>) <i>must</i> consist of one of the letters 'E' or 'W' (for East or West).</font>
+</p>
+
+<p><font SIZE="2">4. The geocode information <i>should</i> be interchanged as latitude and
+longitude in degrees, minutes, seconds and direction. Decimal degrees <i>must </i>be
+converted to degrees, minutes and seconds before the data are transferred.</font> </p>
+
+<p><font SIZE="2">5. Grid references <i>should</i> be converted to degrees, minutes,
+seconds and direction before data are transferred. <br>
+</font></p>
+
+<p><font SIZE="2">To indicate a range of latitudes and longitudes, a duplicate set of
+latitude and longitude fields will be required. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Notes</i>: The ABIS standard indicates a single 8�character field,
+the first three of which are degrees, the second two minutes, the third two seconds and
+last one direction. This standard is not followed in HISPID3. <br>
+</font></p>
+
+<p><font SIZE="2">When this field is selected, then the <b>Latitude</b> fields must be
+used, not the <b>Spatial Grid</b> fields.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917700">Longitude, </a>Minutes</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">lonmin</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: LONGMINH, LONGMINL <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The minutes of longitude of the collection locality,
+as quoted from the label or derived.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; 0 � 59, any valid and
+biogeographically meaningful longitude in minutes.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: See Comment under <b>Longitude, degrees</b>.<br>
+</font></p>
+
+<p><font SIZE="2">1. If the longitude degrees (<b>Longitude, Degrees</b> field) is not
+known, then this and the following longitude fields <i>must</i> be left unfilled.</font> </p>
+
+<p><font SIZE="2">2. If the longitude minutes (<b>Longitude, Minutes</b> field) is not
+known, then this and longitude seconds (<b>Longitude, Seconds</b> field) <i>must</i> be
+left unfilled.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917701">Longitude, </a>Seconds</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">lonsec</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: LONGSECH, LONGSECH<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The seconds of longitude of the collection, as
+quoted from the label or derived. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; 0 � 59, any valid and
+biogeographically meaningful longitude in seconds.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: See Comment under <b>Longitude, Degrees</b>.<br>
+</font></p>
+
+<p><font SIZE="2">If the value for this field is unknown, then this field <i>must </i>be
+left unfilled.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917702">Longitude, Direction</a> Flag</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">londir</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: LONGDIRHIGH, LONGDIRLOW<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The abbreviated direction of longitude of the
+collection locality, relative to Greenwich, as quoted from the label or derived.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; E or W.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: See Comment under <b>Longitude, Degrees</b>.<br>
+</font></p>
+
+<p><font SIZE="2">If the <b>Longitude, Degrees </b>field is filled, then this field <i>must</i>
+consist of one of the letters 'E' or 'W' (for East or West, respectively).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2">Spatial Grid, Projection</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">sgp <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description:</i> The projection type of the Map Grid system which is
+used to determine the position of the locality from which the plant specimen was
+collected.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: The default system is normally expected to be
+ITRF or derivative standards (eg. MGA94, GDA94).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha, internationally accepted codes (as
+used in SDTS); the default system for HISPID3 is normally expected to be the Universal
+Transverse Mercator Grid System (UTM). Wherever possible, the Eastings and Northings
+should be converted to UTM or a derivative of it. For example, the MGA (Map Grid of
+Australia) is a derivative of UTM and is derived from the projection of latitudes and
+longitudes on the Australian Geodetic Datum (AGD) and Geocentric Datum of Australia (GDA).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: In general, it is recommended that grid references be
+converted to latitudes and longitudes for interchange (refer previous latitude and
+longitude fields).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917703">Spatial Grid</a>, Easting</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">sge <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description:</i> The Map Grid Easting reference of the locality from
+which the plant specimen was collected.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITRF or derivative standards (eg. MGA94,
+GDA94).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; any valid grid reference, in
+metres. The Easting must consists of the following two elements:<br>
+</font>
+
+<ul>
+  <li><b><font SIZE="2">Hemisphere Indicator Code</font></b> </li>
+</ul>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="206"><i><font SIZE="2">Hemisphere Code values in Field </font></i></td>
+    <td WIDTH="189"><i><font SIZE="2">Meaning</font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="206"><font SIZE="2">N </font></td>
+    <td WIDTH="189"><font SIZE="2">Northern Hemisphere Indicator</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="206"><font SIZE="2">S </font></td>
+    <td WIDTH="189"><font SIZE="2">Southern Hemisphere Indicator </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2">Note: This single letter code <b>must </b>preface the Easting.<br>
+</font>
+
+<ul>
+  <li><b><font SIZE="2">Six Integer Easting</font></b> </li>
+</ul>
+
+<p><font SIZE="2">Note: The complete Easting must always be cited as a six-digit integer
+or to the level of accuracy recorded by truncation from the right.<br>
+</font></p>
+
+<p><font SIZE="2">An example of a complete Grid Easting reference would be S347000. An
+example of an Easting to the nearest kilometre for the same locality would be S347.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: In general, it is recommended that grid references be
+converted to latitudes and longitudes for interchange (refer previous latitude and
+longitude fields). When this field is selectred for transfer then <b>Spatial Grid,
+Northing </b>must also be used, not the Latitude and Longitude fields.<br>
+</font></p>
+
+<p><font SIZE="2">Note: Grid Zone designation codes must not be used. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2">Spatial Grid, Northing</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">sgn <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description:</i> The Map Grid Northing reference of the locality from
+which the plant specimen was collected.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITRF or derivative standards (eg. MGA94,
+GDA94).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; any valid grid reference, in
+metres. The Northing must consists of the following two elements:<br>
+<br>
+</font>
+
+<ul>
+  <li><b><font SIZE="2">Hemisphere Indicator Code</font></b> </li>
+</ul>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="215"><i><font SIZE="2">Hemisphere Code values in Field </font></i></td>
+    <td WIDTH="198"><i><font SIZE="2">Meaning</font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="215"><font SIZE="2">N </font></td>
+    <td WIDTH="198"><font SIZE="2">Northern Hemisphere Indicator</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="215"><font SIZE="2">S </font></td>
+    <td WIDTH="198"><font SIZE="2">Southern Hemisphere Indicator </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2">Note: This single letter code <b>must </b>preface the Northing. <br>
+</font>
+
+<ul>
+  <li><b><font SIZE="2">Seven Integer Northing</font></b> </li>
+</ul>
+
+<p><font SIZE="2">Note: The complete Northing must always be cited as a seven-digit
+integer or to the level of accuracy recorded by truncation from the right.</font> </p>
+
+<p><font SIZE="2">An example of a complete Grid Northing reference would be S5739000. An
+example of Grid Northing to the nearest kilometre for the same locality would be S5739. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: In general, it is recommended that grid references be
+converted to latitudes and longitudes for interchange (refer previous latitude and
+longitude fields). When this field is selectred for transfer then <b>Spatial Grid, Easting
+</b>must also be used, not the Latitude and Longitude fields.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Note:</i> Grid Zone designation codes must not be used.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917704">Accuracy of Geocode</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">geoacy</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: LATACCUR, LONGACCUR<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description:</i> The precision of the latitude and longitude of the
+record.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: SDTS, ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Real; in metres.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: If the latitude and longitude are not known, or the
+accuracy is in doubt, then this field should be left unfilled and hence, not interchanged.
+<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917705">Source of Geocode precision</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">geosou <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: Flag indicating the source of the geocode and
+precision calculations. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any value as listed in the following
+table:<br>
+</font></p>
+
+<p><i><font SIZE="2">Values in Field<br>
+</font></i></p>
+
+<p><font SIZE="2">collector</font> </p>
+
+<p><font SIZE="2">compiler</font> </p>
+
+<p><font SIZE="2">generalised arbitrary point</font> </p>
+
+<p><font SIZE="2">automatically generated. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: The geocodes provided by the plant 'collector' are
+usually from GPS readings, maps on�site, extracted from field books or from the herbarium
+label. Those provided by the database 'compiler' are derived from the locality information
+provided by the collector. Computer-generated geocodes are either derived from a nearest
+named place ('generalised arbitrary point') or from a stated locality. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917706">Nearest Named Place</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">nnp</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: STANLOC (?)<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The nearest named place to the locality of the
+collection, 1:100 000 topographic map series.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, AUSLIG Master Name File<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid place name on 1:100 000
+topographic map series, conventional capitalisation of the first letter of place names. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Uncertainty with the application of this field to
+historical material, reduces its usefulness. However individual institutions may choose to
+use it as part of their core data and so make it available for interchange.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h3><a NAME="_Toc366998643">HABITAT GROUP</a><br>
+</h3>
+
+<p><font SIZE="2">This group of fields describes the physical and environmental
+characteristics of the locality in which the plant was collected as opposed to the
+characteristics of the plant itself.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917708">Habitat</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">hab</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: HABITAT <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: Description of the habitat of the accession,
+including the geology and soil type in which the plant grows, as well as the associated
+species of the community from which this accession was collected. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; free text, any meaningful
+habitat descriptions. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This information is usually provided by the original
+collector. <br>
+</font></p>
+
+<p><font SIZE="2">This is an aggregate field, containing information that could be divided
+among the following fields. In fact, many herbaria have entries for these segregate fields
+in their field note books.<br>
+</font></p>
+
+<p><font SIZE="2">Since there are no universally accepted schemes for the classification
+of soils, vegetation, landforms and substrates that modern collectors can be expected to
+follow, the information in this field is regarded as free text. Furthermore, to translate
+a collector's historical descriptions into modern schemes is prone to error and
+misinterpretation.<br>
+</font></p>
+
+<p><font SIZE="2">Institutions with entirely or partially codified habitat data will have
+to expand the codes prior to interchange. <br>
+</font></p>
+
+<p><font SIZE="2">Institutions with habitat data (as defined here) stored in discrete
+fields <i>must</i> combine these fields prior to interchange if they are to use this field
+in the transfer format. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917709">Topography</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">top</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: GEOLOGY (?)<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: A description of the topography of the habitat from
+which the specimen was collected. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; free text.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Refer <i>Comments</i> under <b>Habitat</b>.<br>
+</font></p>
+
+<p><font SIZE="2">Information in this field includes landform, situation, etc.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917710">Aspect</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">asp <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The abbreviated aspect or outlook of the site from
+which the plant was collected <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid directional or aspect
+abbreviation.<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="121"><i><font SIZE="2">Values in Field </font></i></td>
+    <td WIDTH="85"><i><font SIZE="2">Meaning </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">N</font></td>
+    <td WIDTH="85"><font SIZE="2">North</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">S</font></td>
+    <td WIDTH="85"><font SIZE="2">South</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">E</font></td>
+    <td WIDTH="85"><font SIZE="2">East</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">W</font></td>
+    <td WIDTH="85"><font SIZE="2">West</font> </td>
+  </tr>
+</table>
+</center></div>
+
+<table>
+  <tr>
+    <td WIDTH="73"><font SIZE="2">also </font></td>
+    <td WIDTH="517"><font SIZE="2">NE, SE, NW, SW, NNE, ENE, ESE, SSE, NNW, WNW, WSW, SSW.</font>
+    </td>
+  </tr>
+</table>
+
+<table>
+  <tr>
+    <td WIDTH="73"><font SIZE="2">also </font></td>
+    <td WIDTH="517"><font SIZE="2">Open Used to refer to a plain or ridge crest</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="73"></td>
+    <td WIDTH="517"><font SIZE="2">Closed Used to refer to a valley or ravine</font> </td>
+  </tr>
+</table>
+
+<p><font SIZE="2"><i>Comments</i>: Refer <i>Comments</i> under <b>Habitat</b>.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917711">Substrate</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">sub <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The substrate or parent rock material in the habitat
+from which the specimen was collected.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; free text.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Refer <i>Comments</i> under <b>Habitat</b>.<br>
+</font></p>
+
+<p><font SIZE="2">This field should<i> not</i> include descriptions of soil type.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917712">Soil Type</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">soil</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: SOILS<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: Description of the surface soil type from which the
+specimen was collected. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; free text.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Refer <i>Comments</i> under <b>Habitat</b>.<br>
+</font></p>
+
+<p><font SIZE="2">In many cases it is difficult to separate soil and substrate information
+from a habitat description. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917713">Vegetation</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">veg</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: VEGETATION <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: Description of the vegetation from which the
+specimen was collected. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; free text.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Refer <i>Comments</i> under<b> Habitat</b>.<br>
+</font></p>
+
+<p><font SIZE="2">The contents of this field are sometime inseparable from the contents of
+the next field, <b>Associated Species</b>. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917714">Associated </a>Species</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">asspp <br>
+</font></h6>
+
+<p><font SIZE="2">Description: A list of associated species found in the same habitat as
+the collected specimen.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; free text, scientific names (with
+standard Capitalisation) or non-scientific names.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: In most herbaria, this field is combined with the
+previous field as part of the vegetation description; with historical material it is
+sometimes difficult to separate these two fields.<br>
+</font></p>
+
+<p><font SIZE="2">Refer<i> Comments </i>under <b>Habitat</b> and <b>Vegetation</b>. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h3><a NAME="_Toc366998644">COLLECTION GROUP</a><br>
+</h3>
+
+<p><font SIZE="2">This group of fields deals with all the descriptive and coded
+information that describes the collector's names, field numbers, and dates of collection. <br>
+</font></p>
+
+<p><font SIZE="2">It</font><font SIZE="1"> </font><font SIZE="2">does not cover
+descriptive information about the plant itself nor habitat information (refer previous and
+following groups).<br>
+</font></p>
+
+<p><font SIZE="2">Where relevant, all of the standard HISPID3 fields in this group refer
+to the original wild source collection information (refer <b>LOCATION GROUP</b>, above for
+further details).<br>
+</font></p>
+
+<h2><a NAME="_Toc366998645">Subsequent Collection Fields</a> </h2>
+
+<p><font SIZE="2">If the current accession was taken from a secondary source (eg.
+cultivated material, of known or unknown wild source), then the relevant field identifiers
+would all be prefaced by the word 'Subsequent' and the relevant Transfer Codes would be
+prefaced by a lowercase 's'. For example, the field which contains the information about
+the collector's name of the current accession which was taken from cultivated material
+would be known as <b>Subsequent Collector's Name and the Transfer Code would be scnam</b>.
+The same <i>Domain/Range/Values</i> and <i>Comments</i> apply for these 'Subsequent'
+fields as for the relevant 'primary' data fields. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917717">Primary Collector's Name(s)</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">cnam</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: COLLECTOR <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The name of the person or persons who made the
+collection from the wild on which this record is based, and whose collection number is
+cited in the next field (refer <b>Collector's Identifier</b> field). <br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF, TLR<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid collector's name, primary
+collector's family name (surname) followed by comma and space (, ) then initials (all in
+uppercase and each separated by fullstops). All initials and first letter of the
+collector's family name in uppercase. For example, Chambers, P.F. For exceptions to this
+format, refer <i>Comments</i> (below). <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: The collection number of the record (refer <b>Collector's
+Identifier</b>) is regarded as being assigned by the primary collector of the material (as
+cited in this field).<br>
+</font></p>
+
+<p><font SIZE="2">If more than one primary collector is associated with the collection
+number(cf. <b>Secondary Collector's Name </b>field, below), then the names of these
+collectors should be cited in this field, with the comma and space used to separate these
+multiple collectors. For example, Tan, F., Jeffreys, R.S. <br>
+</font></p>
+
+<p><font SIZE="2">If necessary, the first and or other given names should be spelt out
+when there is a known chance of confusion. For example, to distinguish between Wilson,
+Paul G. and Wilson, Peter G. (with a space after the given name; no punctuation, except as
+separator between two names, as described above).<br>
+</font></p>
+
+<p><font SIZE="2">If only one person collected the material from the wild, as represented
+by this record, then the person's name <i>must</i> be entered only in this field.<br>
+</font></p>
+
+<p><font SIZE="2">Titles should be omitted. <br>
+</font></p>
+
+<p><font SIZE="2">If the family name (surname) consists of a preposition and a
+substantive, as in many European names (eg. C.G.G.J. van Steenis), then the preposition is
+in lowercase and the substantive has a Capital first letter. The remaining letters are in
+lowercase. Names of this form should be transferred as follows:<br>
+</font></p>
+
+<p><font SIZE="2">cnam &quot;Steenis, C.G.G.J. van&quot;,<br>
+</font></p>
+
+<p><font SIZE="2">Other examples of similar form include: de la Salle, d'Entrecasteaux,
+van Royen. However, it is important to note that many of these names have been anglicised,
+particularly in America, such that both parts of the family name are treated as the
+substantive. In such examples, these names are to be transferred as follows: <br>
+</font></p>
+
+<p><font SIZE="2">cnam &quot;De Nardi, J.C.&quot;, <br>
+</font></p>
+
+<p><font SIZE="2">The prefixes O', Mac' Mc' and M' (eg. MacDougal, McKenzie, O'Donnell)
+should all be treated as part of the substantive and hence transferred as part of the
+family name. For example: <br>
+</font></p>
+
+<p><font SIZE="2">cnam &quot;McKenzie, V.&quot;, <br>
+</font></p>
+
+<p><font SIZE="2">Hyphenated given names should be tranferred as all uppercase, with the
+first and last initial separated by a hyphen (without spaces), and only the last initial
+terminated by a fullstop. For example:<br>
+</font></p>
+
+<p><font SIZE="2">cnam &quot;Quirico, A-L.&quot;,</font> </p>
+
+<p><font SIZE="2">cnam &quot;Peng, C-I.&quot;, <br>
+</font></p>
+
+<p><font SIZE="2">ABIS includes all collectors in one field in the format: surname, comma,
+initials. This is not followed in the HISPID3 standard.<br>
+</font></p>
+
+<p><font SIZE="2">If the collector of the record is <i>unknown</i>, then this field should
+contain the value 'Anonymous'. <br>
+</font></p>
+
+<p><font SIZE="2">Interpreted information should be enclosed in square brackets, eg.
+Anonymous [? F. von Mueller] <br>
+</font></p>
+
+<p><font SIZE="2">The use of a personal herbarium is admissible here: eg. Anonymous (Herb.
+J.M. Black).<br>
+<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917718">Collector's</a> Identifier</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">cid</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: COLLPREFIX, COLLNUMBER, COLLSUFFIX <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The sequential or other codified number given to the
+specimen at the time of collection, by the primary collector(s), usually as on specimen
+label.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF, TLR<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric. <br>
+</font></p>
+
+<p><font SIZE="2">1. The <b>Collector's Identifier</b> may consist of any characters in
+the ASCII character subset.</font> </p>
+
+<p><font SIZE="2">2. If the <b>Primary Collector's Name</b> is unknown, then this field
+would normally <i>not</i> be filled.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: <br>
+</font></p>
+
+<p><font SIZE="2">If the <b>Collector's Identifier</b> is part of an institutional series,
+then the institution's code should be included as part of the field number.<br>
+</font></p>
+
+<p><font SIZE="2">Collector's initials should not be included as part of the field number.<br>
+</font></p>
+
+<p><font SIZE="2">If a number or component is interpreted in any way, then the interpreted
+part should be enclosed in brackets.<br>
+</font></p>
+
+<p><font SIZE="2">Care should be taken to avoid confusion with institutional collection
+series and sheet numbers. Numbers assigned to the specimen after collection should not be
+used.<br>
+</font></p>
+
+<p><font SIZE="2">If the collection number is not known, then this field should contain
+the value 's.n.'<br>
+</font></p>
+
+<p><font SIZE="2">The proposed TDWG specimen standards include number prefixes and
+suffixes. The interpretation of what constitutes these is likely to create more problems
+than it solves, so the number is treated as a single unit in HISPID3. <br>
+</font></p>
+
+<p><font SIZE="2">The ABIS standards include a former collection number in this field but
+this creates problems if the specimen has also been assigned its own field number.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917719">Secondary Collector's Name</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">cnam2</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: COLLTEAM <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: Other persons responsible for the collection (from
+the wild) together with the primary collector of this record.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid collector's name, secondary
+collector's family name (surname) followed by comma and space (, ) then initials (all in
+uppercase and each separated by fullstops)(refer <b>Primary Collector's Name </b>field for
+further details).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Refer <i>Comments</i> under <b>Collector's Name</b>.<br>
+</font></p>
+
+<p><font SIZE="2">Most commonly this field will not be filled, which implies a single
+collector; it should not be filled if the <b>Primary Collector's Name(s)</b> field is not
+filled.<br>
+</font></p>
+
+<p><font SIZE="2">If there are multiple secondary collectors, then the names of these
+collectors should be cited in this field, with the comma and space used to separate these
+multiple collectors. For example, Campbell, E.D., Lindley, S.A. <br>
+</font></p>
+
+<p><font SIZE="2">If necessary, the first and or other given names should be spelt out
+when there is a known chance of confusion. For example, to distinguish between Wilson,
+Paul G. and Wilson, Peter G. (with a space after the given name; no punctuation, except as
+separator between two names, as described above).<br>
+</font></p>
+
+<p><font SIZE="2">Titles should be omitted. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917720">'Per' </a>Collector</font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">cper <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: Amateur or casual collector who collected specimen
+for primary collector. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid collector's family name
+(surname) followed by comma, then space and initials (refer <b>Primary Collector's Name(s)</b>
+field).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917721"><font SIZE="2">Collection Date</font></a> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">cdat</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: COLLDATE <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The date on which the material was collected, as
+represented by this record or, if a second collection date is provided (refer <b>Second
+Collection </b>Date field below), then this field contains the earlier collection date.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; any chronologically acceptable
+date, year (4 digits) followed by month (2 digits) and then day (2 digits), without spaces
+between each.<br>
+</font></p>
+
+<p><font SIZE="2">1. In this notation, leading zeroes must be included for months and
+days, ie. January is coded as '01' not '1' and the 4th day is coded as '04' not '4'.<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="83"><font SIZE="2"><i>Example:</i> </font></td>
+    <td WIDTH="85"><font SIZE="2">19851109 </font></td>
+    <td WIDTH="132"><font SIZE="2">9 November 1985</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="83"></td>
+    <td WIDTH="85"><font SIZE="2">19510203</font> </td>
+    <td WIDTH="132"><font SIZE="2">3 February 1951</font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2">2. If the day of the month is not known, then the last two digits should
+be omitted.</font> </p>
+
+<p><font SIZE="2"><i>Example</i>: March 1901 would preferably be transferred as 190103.<br>
+</font></p>
+
+<p><font SIZE="2">3. If the day and month are not known, the last four digits should be
+omitted and just the 4 digit year information interchanged.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Note:</i> The year is transferred as a full 4�digit number to
+facilitate the use of the system in the next century, as well as to track verifications
+from the previous century.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917722"><font SIZE="2">Second Collection Date</font></a> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">cdat2</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: COLLDATE2 <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The most recent date on which the material was
+collected, as represented by this record, when a range of collection dates are provided
+(refer <b>Collection Date</b> field above).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant Standards</i>: ABIS, ITF<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; any chronologically acceptable
+date, year (4 digits) followed by month (2 digits) and then day (2 digits), without spaces
+between each.<br>
+</font></p>
+
+<p><font SIZE="2">1. In this notation, leading zeroes must be included for months and
+days, ie. January is coded as '01' not '1' and the 4th day is coded as '04' not '4'.<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="83"><font SIZE="2"><i>Example:</i> </font></td>
+    <td WIDTH="87"><font SIZE="2">19660419 </font></td>
+    <td WIDTH="121"><font SIZE="2">19 April 1966</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="83"></td>
+    <td WIDTH="87"><font SIZE="2">19451202</font> </td>
+    <td WIDTH="121"><font SIZE="2">2 December 1945</font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2">2. If the day of the month is not known, then the last two digits should
+be omitted.</font> </p>
+
+<p><font SIZE="2"><i>Example</i>: June 1911 would preferably be transferred as 191106.<br>
+</font></p>
+
+<p><font SIZE="2">3. If the day and month are not known, the last four digits should be
+omitted and just the 4 digit year information interchanged.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Notes</i>: The year as a full 4�digit number to facilitate the use
+of the system in the next century, as well as to track verifications from the previous
+century.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917723">General Text Collection Date</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">texcdat <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: A field which allows the description of imprecise
+collection dates which do not conform to the international 'Date' data standard. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha-Integer; any chronologically
+acceptable date which can not be converted to the format of the previous collection date
+fields. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This field allows for the interchange of the following
+types of collection date information:<br>
+</font></p>
+
+<p><font SIZE="2">For example:<br>
+</font></p>
+
+<p><font SIZE="2">'Spring 1912', 'late 1800's', 'end of 19th Century' <br>
+<br>
+</font></p>
+
+<hr>
+
+<h3><a NAME="_Toc366998646">KIND OF COLLECTION</a>, ADDITIONAL COMPONENTS and VOUCHER
+COLLECTIONS <br>
+</h3>
+
+<p><font SIZE="2">HISPID and ITF grouped these data into two fields (namely 'Kind of
+Collection &amp; Additional Components Flag' and 'Voucher Flag') with several categories
+included in each. However, it may be preferable to consider separating each category into
+distinct fields for transfer. This would readily enable unique identifiers (such as
+institutional 'spirit' numbers and photographic numbers) to be transferred with each
+category. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917725">Kind of Collection &amp; Additional Components
+Flag</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">ckin</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: NATOBJECT (?)<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The kind of specimen�associated material
+represented by this record number, such as sheet, packets, spirit, slides etc., not
+propagating material.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: TLR <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>:, Alphabetic; this field must consist of one
+of the values in the table below.<br>
+</font></p>
+
+<table>
+  <tr>
+    <td WIDTH="111"><i><font SIZE="2">Value of Field </font></i></td>
+    <td WIDTH="479"><i><font SIZE="2">Meaning </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Alcohol </font></td>
+    <td WIDTH="479"><font SIZE="2">Alcohol or any other fluid preserved material</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Bark </font></td>
+    <td WIDTH="479"><font SIZE="2">Bark sample</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Boxed </font></td>
+    <td WIDTH="479"><font SIZE="2">Boxed specimen</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Cytological </font></td>
+    <td WIDTH="479"><font SIZE="2">Cytological preparation</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Fruit </font></td>
+    <td WIDTH="479"><font SIZE="2">Fruit, carpological</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Illustration</font></td>
+    <td WIDTH="479"><font SIZE="2">Illustrations</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Image </font></td>
+    <td WIDTH="479"><font SIZE="2">Electronic image</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Other </font></td>
+    <td WIDTH="479"><font SIZE="2">Other</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Packet </font></td>
+    <td WIDTH="479"><font SIZE="2">Specimen stored in Packet</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Pollen </font></td>
+    <td WIDTH="479"><font SIZE="2">Pollen sample</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Print </font></td>
+    <td WIDTH="479"><font SIZE="2">Negatives, black &amp; white and colour photographic prints
+    (including Cibachrome)</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Reference </font></td>
+    <td WIDTH="479"><font SIZE="2">Reference herbarium</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Seed </font></td>
+    <td WIDTH="479"><font SIZE="2">Seed collection</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Sheet </font></td>
+    <td WIDTH="479"><font SIZE="2">Herbarium sheet</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Slide </font></td>
+    <td WIDTH="479"><font SIZE="2">Microscope slides</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Transparency </font></td>
+    <td WIDTH="479"><font SIZE="2">Transparencies, colour slides</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Vertical </font></td>
+    <td WIDTH="479"><font SIZE="2">Vertically filed,</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">Wood </font></td>
+    <td WIDTH="479"><font SIZE="2">Wood sample </font></td>
+  </tr>
+</table>
+
+<p><font SIZE="2"><i>Comments</i>: The difficulty with this field for interchange is that
+this information may only describe the attributes of the collection in one institution
+(namely, the originating institution). It may not be an accurate description of the
+interchange material, so care is needed in using this field as part of the transfer file
+for exchange material. <br>
+</font></p>
+
+<p><font SIZE="2">Since a single collection may have more than one of the above
+attributes, the relevant individual descriptor codes should be transferred in alphabetical
+order, separated by a comma and a space. For example: if a collection consists of an
+herbarium sheet, alcohol-preserved material, and a colour photographic print, then this
+information would be transferred as <b>Alcohol, Print, Sheet </b>(note: each codes is
+singular, not plural).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917726">Voucher Flag</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">vou <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: A flag to indicate if the specimen serves as a
+voucher for some special purpose.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphabetic; this field must consist of one
+of the values in the table below: <br>
+</font></p>
+
+<table>
+  <tr>
+    <td WIDTH="121"><i><font SIZE="2">Value of Field </font></i></td>
+    <td WIDTH="236"><i><font SIZE="2">Meaning </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Anatomical </font></td>
+    <td WIDTH="236"><font SIZE="2">anatomical</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Cytological </font></td>
+    <td WIDTH="236"><font SIZE="2">cytological</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">DNA </font></td>
+    <td WIDTH="236"><font SIZE="2">DNA Studies</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Ecological </font></td>
+    <td WIDTH="236"><font SIZE="2">ecological</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Flora </font></td>
+    <td WIDTH="236"><font SIZE="2">Flora project</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Illustration </font></td>
+    <td WIDTH="236"><font SIZE="2">illustration</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Indigenous </font></td>
+    <td WIDTH="236"><font SIZE="2">indigenous uses, ethnobotany</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Living </font></td>
+    <td WIDTH="236"><font SIZE="2">living, including seed bank</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Other </font></td>
+    <td WIDTH="236"><font SIZE="2">palynological</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Photograph </font></td>
+    <td WIDTH="236"><font SIZE="2">photograph</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Phytochemical </font></td>
+    <td WIDTH="236"><font SIZE="2">phytochemical, pharmacological</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Unknown </font></td>
+    <td WIDTH="236"><font SIZE="2">voucher for unknown purpose</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Zoological </font></td>
+    <td WIDTH="236"><font SIZE="2">zoological</font> </td>
+  </tr>
+</table>
+
+<p><font SIZE="2"><i>Comments</i>: The presence of these flags does not necessarily imply
+the existence of supplementary material (eg. spirit, or slides) as described in the <b>Kind
+of Collection &amp; Additional Components Flag</b> field (above), although some may have
+been prepared at some stage. <br>
+</font></p>
+
+<p><font SIZE="2">Since a single collection may be a voucher for more than one of the
+above categories, the relevant individual descriptor codes should be transferred in
+alphabetical order, separated by a comma and a space. For example: if a collection is a
+voucher for the current 'Flora of Australia' project and for an ecological survey, then
+this information would be transferred as <b>Ecological, Flora </b>(note: each code is
+singular, not plural).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917727">Number of Sheets, Parts</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">numshe</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: OBJECTS <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The number of herbarium sheets, packets, boxes,
+etc., that make up the specimen represented by this record.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; any reasonable number of parts.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This field is most useful for the control of loan
+specimens that consist of multiple sheets or parts. It may not be so useful in other
+interchange files because this information may only describe the attributes of the
+collection in one institution (namely, the originating institution). It may not be an
+accurate description of the interchange material, so care is needed in using this field as
+part of the transfer file.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917728">Type of Cultivated Material Flag</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">tcul <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: A code indicating the presence of living material
+for cultivation, collected at the time of collection of the specimen on which the record
+is based.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphabetic; this field must consist of one
+of the values in the table below: <br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="121"><font SIZE="2"><i>Values in Field</i> </font></td>
+    <td WIDTH="151"><i><font SIZE="2">Meaning </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Cutting </font></td>
+    <td WIDTH="151"><font SIZE="2">cuttings</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Division </font></td>
+    <td WIDTH="151"><font SIZE="2">division (of clumps etc.)</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Plant </font></td>
+    <td WIDTH="151"><font SIZE="2">plants (whole)</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">Seed </font></td>
+    <td WIDTH="151"><font SIZE="2">seeds</font> </td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Comments</i>: This field applies to the type of material gathered and
+not to the source of material. <br>
+</font></p>
+
+<p><font SIZE="2">If this field is not filled then it can be assumed that either no
+propagating material was collected or that the existence of propagating material was not
+recorded.<br>
+</font></p>
+
+<p><font SIZE="2">The presence of a propagating material code does not necessarily imply
+that live material is still in existence in cultivation.<br>
+</font></p>
+
+<p><font SIZE="2">As with the <b>Kind Of Collection &amp; Additional Components</b><i> </i>field,
+if more than one type of material was collected for cultivation, then the relevant
+individual descriptor codes should be transferred in alphabetical order, separated by a
+comma and a space. For example: the information for a collection which consisted of
+cuttings and seeds would be transferred as <b>Cutting, Seed</b> (Note: each code is
+singular, not plural). <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917729">Provenance Type Flag</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">prot <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: A code to indicate the provenance of the accession
+of living material represented by the herbarium voucher.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphabetic; this field must consist of one
+of the values in the table below: <br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="112"><font SIZE="2"><i>Values in Field</i> </font></td>
+    <td WIDTH="383"><i><font SIZE="2">Meaning </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="112"><font SIZE="2">Cult. ex Wild </font></td>
+    <td WIDTH="383"><font SIZE="2">Propagule(s) from a wild source plant in cultivation </font></td>
+  </tr>
+  <tr>
+    <td WIDTH="112"><font SIZE="2">Cult. non-wild </font></td>
+    <td WIDTH="383"><font SIZE="2">Accession not of wild source</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="112"><font SIZE="2">Unknown </font></td>
+    <td WIDTH="383"><font SIZE="2">Insufficient data to determine which of the above
+    categories apply</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="112"><font SIZE="2">Wild </font></td>
+    <td WIDTH="383"><font SIZE="2">Accession of wild source </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Comments</i>: The terms outlined above are defined as follows:<br>
+</font></p>
+
+<table>
+  <tr>
+    <td WIDTH="121"><font SIZE="2"><b>Cult. ex Wild</b> <br>
+    </font></td>
+    <td WIDTH="576"><font SIZE="2">Accessions derived by propagation directly from an original
+    wild source plant. The method of propagation must be recorded in the Propagation History
+    field. If the propagation is not directly from the original wild source plant, a complete
+    history of the intermediate propagation steps must be known, otherwise the accession
+    should be placed in the following category.</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2"><b>Cult. non-Wild</b> <br>
+    </font></td>
+    <td WIDTH="576"><font SIZE="2">Accessions derived from cultivated plants where the
+    immediate source plant does not have a propagation history that can be traced in detail to
+    a wild plant. This category normally includes all cultivars.</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2"><b>Unknown</b> </font></td>
+    <td WIDTH="576"><font SIZE="2">Accessions where there is insufficient data or knowledge to
+    know which of the three above categories applies.</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2"><b>Wild</b> </font></td>
+    <td WIDTH="576"><font SIZE="2">Accessions which originate from material collected in the
+    wild. The accession has not been propagated further, except in the case of plants that may
+    have been grown on from the original stock. The accession may have come directly from the
+    wild, or from a botanic garden or gene bank acting as a distribution centre. Accessions in
+    this category will usually have accompanying collection data, but the category also
+    includes accessions which are known to be of direct wild origin but which do not have such
+    additional data. </font></td>
+  </tr>
+</table>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917730">Propagation History Flag</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">prohis <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: A code to indicate the nature of the production of
+the living plant material vouched by the herbarium material, for use in association with
+the previous field, Provenance Type<b> Flag</b>.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards: </i>ITF <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: One or two alphabetic letters, uppercase, as
+designated below. <br>
+</font></p>
+
+<p><font SIZE="2">The entry must be one of the following values:<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="111"><i><font SIZE="2">Values in Field </font></i></td>
+    <td WIDTH="359"><i><font SIZE="2">Meaning </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">I </font></td>
+    <td WIDTH="359"><font SIZE="2">Individual wild plant(s)</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">S </font></td>
+    <td WIDTH="359"><font SIZE="2">Seed or plant arising from seed (excluding apomixis)</font>
+    </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">SA </font></td>
+    <td WIDTH="359"><font SIZE="2">From open pollination (from the wild)</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">SB </font></td>
+    <td WIDTH="359"><font SIZE="2">From controlled pollination</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">SC </font></td>
+    <td WIDTH="359"><font SIZE="2">From plants that are isolated and definitely
+    self-pollinated</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">V </font></td>
+    <td WIDTH="359"><font SIZE="2">Plant material derived asexually</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">VA </font></td>
+    <td WIDTH="359"><font SIZE="2">From vegetative reproduction (including vegetative
+    apomixis)</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">VB </font></td>
+    <td WIDTH="359"><font SIZE="2">From apomictic cloning (agamospermy)</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">U </font></td>
+    <td WIDTH="359"><font SIZE="2">Propagation history uncertain or no information </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><i><font SIZE="2">Comments<br>
+</font></i></p>
+
+<table>
+  <tr>
+    <td WIDTH="45"><font SIZE="2">1. </font></td>
+    <td WIDTH="643"><font SIZE="2">The second character is optional to provide more detailed
+    information to be recorded. It is recommended that both characters are used wherever
+    possible. </font></td>
+  </tr>
+  <tr>
+    <td WIDTH="45"><font SIZE="2">2. </font></td>
+    <td WIDTH="643"><font SIZE="2">The value 'I' refers to complete individuals (or ramets)
+    that have been removed from the wild, or to accessions which are growing naturally within
+    the area of the establishment to which the record system applies. For example, this allows
+    for individuals or groups of individual growing naturally (ie. not deliberately
+    introduced) in reserve areas to receive full accession status.</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="45"><font SIZE="2">3. </font></td>
+    <td WIDTH="643"><font SIZE="2">Seed set by apomixis should be coded 'VB' rather than by
+    any of the 'S' codes.</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="45"><font SIZE="2">4.</font></td>
+    <td WIDTH="643"><font SIZE="2">Most wild-collected seed will be the result of open
+    pollination, and even taxa which are fully self-compatible will normally show a small
+    amount of outbreeding. Only if it is absolutely certain that wild-collected seed was set
+    as the result of selfing (eg. cleistogamy, controlled selfing) should the entry be set to
+    'SC'. Occasionally wild-collected seed will be the result of controlled experimental
+    pollination, where the entry should be set to 'SB' (or 'SC' if selfed), but the majority
+    of wild seed should be coded 'SA'.</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="45"><font SIZE="2">5. </font></td>
+    <td WIDTH="643"><font SIZE="2">Where material has been derived from cuttings, divisions,
+    or other vegetative propagules (including material for micropropagation) of wild plants,
+    the entry should be set to 'VA', and not 'I'. Such vegetative propagules may potentially
+    differ slightly from the wild individual by somatic variation.</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="45"><font SIZE="2">6. </font></td>
+    <td WIDTH="643"><font SIZE="2">If the accession is of wild provenance (Provenance Type = <b>Wild</b>),
+    then Propagation History cannot be '<b>U</b>'.</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="45"><font SIZE="2">7. </font></td>
+    <td WIDTH="643"><font SIZE="2">If Propagation History is 'I' (individual wild plants),
+    Provenance Type must be <b>Wild</b>. </font></td>
+  </tr>
+</table>
+
+<hr>
+
+<h4><a NAME="_Toc363917731"><font SIZE="2">Donor Type Flag</font></a> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">dont <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: A code to indicate the type of donor from which the
+accession was obtained.</font> </p>
+
+<p><font SIZE="2"><i>Relevant standards: </i>ITF</font> </p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: A single uppercase alphabetic letter, as
+designated below:<br>
+</font></p>
+
+<p><font SIZE="2">1. The entry must consist of one of the following characters:<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="111"><i><font SIZE="2">Values in Field</font></i></td>
+    <td WIDTH="302"><i><font SIZE="2">Meaning </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">B </font></td>
+    <td WIDTH="302"><font SIZE="2">Botanic Garden or Arboretum</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">E </font></td>
+    <td WIDTH="302"><font SIZE="2">Expedition</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">G </font></td>
+    <td WIDTH="302"><font SIZE="2">Gene Bank</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">H </font></td>
+    <td WIDTH="302"><font SIZE="2">Horticultural Association or Garden Club</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">I </font></td>
+    <td WIDTH="302"><font SIZE="2">Individual</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">M </font></td>
+    <td WIDTH="302"><font SIZE="2">Municipal Department</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">N </font></td>
+    <td WIDTH="302"><font SIZE="2">Nursery or other commercial establishment</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">O </font></td>
+    <td WIDTH="302"><font SIZE="2">Other</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">R </font></td>
+    <td WIDTH="302"><font SIZE="2">Other research, field or experimental station</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">S </font></td>
+    <td WIDTH="302"><font SIZE="2">Staff of institution to which record system applies</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">V </font></td>
+    <td WIDTH="302"><font SIZE="2">University Department</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="111"><font SIZE="2">U </font></td>
+    <td WIDTH="302"><font SIZE="2">Unknown or not applicable</font> </td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2">2. If more than one individual descriptor code is applicable to this
+record, then this information should be transferred in alphabetical order, without spaces
+or punctuation. For example: the information for a collection which was collected on an
+expedition by a University Department would be transferred as <b>EV</b> (also refer <i>Comments</i>
+below). <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: The ITF2 transfer format recommends that 'if more than
+one entry applies (eg. a plant collected by the botanic garden staff on an expedition),
+the highest entry in the table should be used. The ITF2 standard lists the above table in
+the following order: E G B R S V H M N I O U.<br>
+</font></p>
+
+<p><font SIZE="2">The purpose of this field is to allow the inclusion of information about
+the contents of the <b>Donor</b> Field. If the value for <b>Donor Type Flag</b> is O, then
+the <b>Donor</b> field description (see below) should be worded so as to indicate the type
+of donor.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917732">Donor</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">don <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The person, institution or business from which the
+accession was obtained.</font> </p>
+
+<p><font SIZE="2"><i>Relevant standards:</i> ITF, Index Herbariorum</font> </p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; free text, use institutional
+code wherever possible.</font> </p>
+
+<p><font SIZE="2"><i>Comments</i>: Plant material may come to an institution from many
+sources and in various ways. The information under these headings cannot be coded or fully
+standardised. The following guidelines should be used wherever possible:<br>
+</font></p>
+
+<table>
+  <tr>
+    <td WIDTH="64"><font SIZE="2">1. </font></td>
+    <td WIDTH="624"><font SIZE="2">Accessions obtained directly from the wild, usually
+    received from the collector. The name of the collector (surname, comma, space, initials
+    with full stops, and standard capitalisation) should be given first, followed by the name
+    of the country or area to which the expedition was made; or if the expedition has its own
+    title, eg. Sino-British Expedition to China, this should be followed by the name of the
+    country or area. Abbreviations or truncations can be used as necessary.</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="64"><font SIZE="2">2. </font></td>
+    <td WIDTH="624"><font SIZE="2">Accessions obtained from other institutions, using standard
+    Index Herbariorum codes, or in full if institution does not have such a code.</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="64"><font SIZE="2">3. </font></td>
+    <td WIDTH="624"><font SIZE="2">Accessions obtained from private individuals. The minimum
+    information should be the person's name (surname, comma, space, initials with full stops,
+    and standard capitalisation) and country. More detail can be added, such as town and
+    province, if necessary to identify collector.</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="64"><font SIZE="2">4. </font></td>
+    <td WIDTH="624"><font SIZE="2">Accessions obtained from horticultural or specialist plant
+    societies. The name of the society (truncated as necessary) followed by the name of the
+    country in which the society is based. Avoid abbreviations where the meaning is not clear.</font>
+    </td>
+  </tr>
+  <tr>
+    <td WIDTH="64"><font SIZE="2">5. </font></td>
+    <td WIDTH="624"><font SIZE="2">Accessions obtained from gene banks, urban parks, garden
+    centres or commercial suppliers. The name of institution (truncated as necessary) followed
+    by the name of the country in which the institution is based.</font> </td>
+  </tr>
+</table>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917733">Donor's Accession Identifier</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">donacc <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: Used when a living accession is transferred from one
+herbarium, garden or gene bank (or other institution that maintains a record system) to
+another, this is the unique identifier from the previous institution's record system.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; the Donor's Accession
+Identifier may consist of any characters in the ASCII characters. It must be prefaced by
+the institutional code of the donating institution.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: If the plant was originally collected by or for the
+donating institution from the wild, or came from a source that did not have a record
+system, then this field should not be filled.<br>
+</font></p>
+
+<p><font SIZE="2">Otherwise, the <b>Donor's Accession Identifier</b> should be a unique
+set of characters that identifies each accession in the donor's record system. Or in the
+case of multiple accessions of the same taxon from one collection site or multiple plants
+derived from a single seed sowing, a single value for the <b>Donor's Accession Identifier</b>
+field is permissible.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Notes</i>: This field is <i>not</i> the Collector's identifier for
+the accession; those data are held under the <b>Collector's Identifier</b> field. It is
+the donor's record system identifier. This identifier is often attached to the sheet in
+the home institution and is not always present on donated or exchanged replicates.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h3><a NAME="_Toc366998647">ADDITIONAL DATA GROUP</a> <br>
+</h3>
+
+<p><font SIZE="2">This group of fields covers information about the plant itself,
+generally those characters that will not be immediately obvious from the preserved
+specimen. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917735">Collection Notes</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">cnot</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: NOTES<br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: This field includes descriptive information about
+this plant record, including habit, shape and colour of vegetative and reproductive parts
+of the plant.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>:<i> </i>Alphanumeric; free text.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This information is usually provided by the collector.<br>
+</font></p>
+
+<p><font SIZE="2">As far as possible, this information should be transcribed verbatim from
+the herbarium label.<br>
+</font></p>
+
+<p><font SIZE="2">Refer <i>Comments</i> under <b>Locality</b>.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Notes: </i>This is an aggregate field, containing information that
+could be divided among the following fields: <b>Habit, Life form</b>, <b>Phenology</b>. In
+fact, many herbaria have entries for these segregate fields in their field notebooks.
+Note: Information about flower colour is not interchanged as a separate field.<br>
+</font></p>
+
+<p><font SIZE="2">The <i>Comments</i> about encoding data under <b>Habitat</b> also apply
+here. Institutions that encode and compartmentalise the information relevant to this field
+will need to expand and combine it into this single <b>Collection Note</b> field prior to
+interchange, if they wish to include this field in the transfer file.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917736">Frequency</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">fre</font> </h6>
+
+<p><font SIZE="2">TDWG Short name: FREQUENCY <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: A description of the local abundance of the taxon
+represented by the record, without any perceived conservation status implied or provided,
+as recorded by the collector.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; free text.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Due to the lack of agreed standards for terms covering
+abundance, the difficulty of interpreting historical material, and the fact that
+statements of abundance are usually embedded in other descriptive text, it seems
+preferable to combine abundance into a more general notes field (eg. <b>Collection Notes</b>).
+However, since ITF2 maintains this information as distinct from the <b>Collection Notes</b>
+field, this information is also included as a distinct field in HISPID3. However, ITF2
+includes frequency assessment data in the <b>Conservation Status (Threat) </b>field.
+Although the latter field is also available in HISPID3, it is recommended that the current
+<b>Frequency</b> field, together with the three <b>Plant Occurrence and Status Scheme</b>
+fields are used to transfer information describing frequency and perceived conservation.
+status. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917737"><font SIZE="2">Conservation Status (Threat)</font></a> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">consta</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: FREQUENCY <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: A description of the local abundance, hence
+perceived conservation status of the taxon represented by the specimen of this record in
+the above habitat, as recorded by the collector.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; free text.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Due to the lack of agreed standards for terms covering
+abundance, the difficulty of interpreting historical material, and the fact that
+statements of abundance are usually embedded in other descriptive text, it seems
+preferable to combine abundance into a more general notes field (eg. <b>Collection Notes</b>).
+However, since ITF2 maintains this information as distinct from the <b>Collection Notes</b>
+field, this field is also included as a distinct field in HISPID3. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917738">Plant Occurrence and Status Scheme 1</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">posnat <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: This field records whether the plant is a native of
+the collection habitat or whether it is a naturalised introduction.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: To be decided.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: It is expected that this field will have values similar
+to the following:<br>
+</font></p>
+
+<p><i><font SIZE="2">Values in Field<br>
+</font></i></p>
+
+<p><font SIZE="2">Natural</font> </p>
+
+<p><font SIZE="2">Naturalised</font> </p>
+
+<p><font SIZE="2">Unknown<br>
+</font></p>
+
+<p><font SIZE="2"><i>Guidelines</i>: World Conservation Monitoring Centre in Cambridge
+(WCMC) are working on this standard, soon to be in press.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917739">Plant Occurrence and Status Scheme 2</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">poscul <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: This field records whether the plant occurs as a
+cultivated specimen or not, in the collection habitat.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: To be decided.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This field records whether the plant is established or
+not established (hence, only maintained as a cultivated plant), in the collection habitat.
+It is expected that this field will have values similar to the following:<br>
+</font></p>
+
+<p><i><font SIZE="2">Values in Field<br>
+</font></i></p>
+
+<p><font SIZE="2">Cultivated</font> </p>
+
+<p><font SIZE="2">Not cultivated</font> </p>
+
+<p><font SIZE="2">Unknown<br>
+</font></p>
+
+<p><font SIZE="2"><i>Guidelines</i>: World Conservation Monitoring Centre in Cambridge
+(WCMC) are working on this standard, soon to be in press.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917740"><font SIZE="2">Plant Occurrence and Status Scheme 3</font></a>
+</h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">posint <br>
+</font></h6>
+
+<h6><font SIZE="2"><i>Description</i>: This field described the method of introduction of
+non-native plants to the collection habitat.<br>
+</font></h6>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: To be decided.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: It is expected that this field will have values similar
+to the following:<br>
+</font></p>
+
+<p><i><font SIZE="2">Values in Field<br>
+</font></i></p>
+
+<p><font SIZE="2">Human</font> </p>
+
+<p><font SIZE="2">Non-human</font> </p>
+
+<p><font SIZE="2">Unknown<br>
+</font></p>
+
+<p><font SIZE="2"><i>Guidelines</i>: World Conservation Monitoring Centre in Cambridge
+(WCMC) are working on this standard, soon to be in press.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917741">Habit, Life form</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">form</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: PLTDESCR <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: A description of the habit or life form of the
+specimen on which the record is based.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; free text, any valid description of a
+plant habit.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Since there are no universally accepted schemes for the
+classification of habit that modern collectors can be expected to follow, the information
+in this field is regarded as free text. Furthermore, to interpolate a collector's
+historical descriptions into modern schemes is prone to error and misinterpretation.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917742">Phenology</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">phe <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The phenological state of the specimen represented
+by this record. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; a value as listed in table below:<br>
+</font></p>
+
+<p><i><font SIZE="2">Values in Field<br>
+</font></i></p>
+
+<p><font SIZE="2">HIGHER PLANTS</font> </p>
+
+<p><font SIZE="2">'FLOWERS' (Pre-fertilisation)</font> </p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="130"><font SIZE="2">bisexual flowers</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="130"><font SIZE="2">buds</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="130"><font SIZE="2">female cones</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="130"><font SIZE="2">female flowers</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="130"><font SIZE="2">flowers</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="130"><font SIZE="2">male/female cones</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="130"><font SIZE="2">male cones</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="130"><font SIZE="2">male flowers</font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2">'FRUITS' (Post-fertilisation)</font> </p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="126"><font SIZE="2">fruit</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="126"><font SIZE="2">fruiting cones</font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2">CRYPTOGAMS</font> </p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="140"><font SIZE="2">gametophyte</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="140"><font SIZE="2">sporophyte</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="140"><font SIZE="2">spore-bearing bodies</font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2">GENERAL TERMS</font> </p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="136"><font SIZE="2">fertile</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="136"><font SIZE="2">sterile</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="136"><font SIZE="2">leafless</font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Comments</i>: If more than one individual descriptor applicable to
+this record, then this information should be transferred in alphabetical order, with each
+descriptor separated by a comma and a space (, ) For example: the information for a
+flowering, leafless collection would be transferred as:<br>
+</font></p>
+
+<p><font SIZE="2">phe &quot;flowers, leafless&quot;, <br>
+<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917744"><font SIZE="2">Non�computerised Data Flag</font></a> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">noncom <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: A single character indication of the presence of
+additional data available on the specimen and not represented in this record. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; Y or N:<br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="117"><i><font SIZE="2">Values in Field </font></i></td>
+    <td WIDTH="180"><i><font SIZE="2">Meaning </font></i></td>
+  </tr>
+  <tr>
+    <td WIDTH="117"><font SIZE="2">N </font></td>
+    <td WIDTH="180"><font SIZE="2">No additional data present</font> </td>
+  </tr>
+  <tr>
+    <td WIDTH="117"><font SIZE="2">Y </font></td>
+    <td WIDTH="180"><font SIZE="2">Additional data present </font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Comments</i>: The existence on the specimen label of extremely
+detailed field notes or botanists' annotations and comments may be flagged in this field.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917745">Miscellaneous Notes</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">misc <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: Any additional information to be transferred
+pertaining to the accession, but not catered for in the preceding fields.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: ITF <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; free text.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917746">Number of Replicates</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">numrep</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: REPLICATES <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: Number of replicate specimens represented by this
+record or collection. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: A count of the replicate specimens indicated on the
+field label, either explicitly or implicitly through the distribution list. This
+information is probably not necessary for interchange, especially if the <b>Replicates
+Destination</b> field is transferred (see below).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917747">Destination of Replicates</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">desrep <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The initial destination(s) of replicate specimens,
+using Index Herbariorum codes.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: Index Herbariorum<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid Index Herbariorum code (in
+uppercase), or name written in full if no code available, separated by comma and space. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: The destinations in this field are the initial, not the
+ultimate, destination. There is no reliable way of checking if and where donated specimens
+may have been redirected.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h3><a NAME="_Toc366998648">LOAN GROUP</a><br>
+</h3>
+
+<p><font SIZE="2">This group of fields contains information pertaining to specimen loan
+transactions. In a normalised database this group of fields fits very comfortably into a
+separate linked table. Some institutions maintain this information in a separate database.
+<br>
+</font></p>
+
+<p><font SIZE="2">To reduce duplication of data entry effort and to facilitate monitoring
+of specimens on loan, specimen data should be exchanged with the specimens going on loan.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917749"><font SIZE="2">Loan Identifier</font></a> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">loaid <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The unique institutional loan number applied with
+the loan sequence number to uniquely identify a specimen on loan.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; with or without other special
+characters.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This can be a simple sequential number series or an
+encoded arrangement involving the year and the loan number within the year. Institutions
+that store a loan number as two separate fields will need to combine the fields prior to
+interchange.<br>
+</font></p>
+
+<p><font SIZE="2">Used in association with the next field, <b>Loan Sequence Number</b>.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917750">Loan Sequence Number</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">loanum <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The sequence of a specimen within a given loan,
+assigned with the <b>Loan Identification </b>to uniquely identify a specimen on loan.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; values starting at 1 and
+sequential.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Used in association with the previous field, <b>Loan
+Identification</b>. <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917751">Loan Destination</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">loades <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: Institution to which the loan is being sent.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Relevant standards</i>: Index Herbariorum<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid Index Herbariorum code (in
+uppercase), or written in full if no code available.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Although this field is described here, the information
+in this field <i>should</i> be included in the file identifier field <b>Description of
+File Contents and other Comments</b> (p. 19).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917752">Loan for Botanist</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">loabot <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: Name of botanist for whom the loan is destined.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid botanist's name, with the
+botanist's family name (surname) first, then comma and space, followed by initials (in
+uppercase and each separated by fullstops), first letter of surname capitalised. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Although this field is described here, the information
+in this field <i>should</i> be included in the file identifier field <b>Description of
+File Contents and other Comments</b> (p. 19).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917753">Loan Despatch Method</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">loadis <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The means by which the loan is being despatched from
+the home institution. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha. <br>
+</font></p>
+<div align="center"><center>
+
+<table ALIGN="CENTER">
+  <tr>
+    <td WIDTH="121"><font SIZE="2">surface mail</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">airmail</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">airfreight</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">road</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">rail</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">courier</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">safe hand</font></td>
+  </tr>
+  <tr>
+    <td WIDTH="121"><font SIZE="2">insured/registered</font></td>
+  </tr>
+</table>
+</center></div>
+
+<p><font SIZE="2"><i>Comments</i>: As with the previous fields, the information in this
+field <i>should</i> be included in the file identifier field <b>Description of File
+Contents and other Comments</b> (p. 19).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917754">Loan Date</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">loadat <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The date the loan is prepared and/or sent<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; year (4 digits) followed by month
+(2 digits) and then day (2 digits), without spaces between each. That is, YYYYMMDD. For
+example, the 8th June 1975 would be transferred in the form 19750608 (refer <b>Collection
+Date</b> for further details).<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Although this field is described here, the information
+in this field is equivalent to the information already included in <b>Date of File </b>field
+(p. 15). Therefore, this information <i>should</i> be included in the latter file
+identifier field.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917755">Loan Return Date</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">loaret <br>
+</font></h6>
+
+<p><font SIZE="2"><i>Description</i>: The date on which the loan is due to be returned to
+the home institution. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; year (4 digits) followed by month
+(2 digits) and then day (2 digits), without spaces between each. That is, YYYYMMDD. For
+example, the 4th February 1996 would be transferred in the form 19960204 (refer <b>Collection
+Date</b> for further details). <br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: This information can be either attached to every
+interchange record or included in the file identifier field <b>Description of File
+Contents and other Comments</b> (p. 19).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h3><a NAME="_Toc366998649">DATA ENTRY AND EDIT GROUP</a><br>
+</h3>
+
+<p><font SIZE="2">The fields in this group record house�keeping details of data entry and
+modification and can be largely automated and transparent to the user.<br>
+</font></p>
+
+<p><font SIZE="2">It is possible and perhaps desirable to keep an in�house audit trail of
+all modifications to the record and not just the last modification.<br>
+</font></p>
+
+<p><font SIZE="2">This group is important in the management of new data and data
+corrections between institutions interchanging information. They provide a useful means of
+tracing the sources of interpreted information and errors. They can also be used to avoid
+the duplication of data entry.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917757">Record Creation Operator</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">crenam</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: CREATEBY <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: Name or sign�on code of the person who created or
+entered the initial data for this record.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alphanumeric; any valid operator name or
+code.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: The use of an unique code here can serve as a link to
+more detailed biographical data.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917758">Record Creation Date</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">credat</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: CREATEDATE <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: Date of data creation or the initial entry of this
+record in database. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; year (4 digits) followed by month
+(2 digits) and then day (2 digits), without spaces between each. That is, YYYYMMDD. For
+example, the 22nd July 1987 would be transferred in the form 19870722 (refer <b>Collection
+Date</b> for further details).<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917759"><font SIZE="2">Record Creation Institution</font></a> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">creins</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: CREATEINST <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description: </i>The institution where this record was created or
+initially entered. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; any valid Index Herbariorum code.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Although this field is described here, this information
+is often equivalent to the contents of the record identifier field <b>Institution Code. In
+these instances</b>, this field need not be transferred. However, if the electronic record
+was originally created at a third institution, then the code of this third institution
+should be included here as it will be different to the entry in the <b>Institution Code</b>
+field.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917760">Record Update Operator</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">modnam</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: UPDATEBY <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: Name or sign�on code of the last person to modify
+or update data for this record. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values: </i>Alphanumeric; any valid operator name or
+code.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: The use of an unique code here can serve as a link to
+more detailed biographical data.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><a NAME="_Toc363917761"><font SIZE="2">Last Edit Date</font></a> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">moddat</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: UPDATEDATE <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: Date of the last modification or update of this
+record.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Integer; year (4 digits) followed by month
+(2 digits) and then day (2 digits), without spaces between each. That is, YYYYMMDD. For
+example, the 14th October 1995 would be transferred in the form 19951014 (refer <b>Collection
+Date</b> for further details). <br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917762">Record Update Institution</a> </font></h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">modins</font> <br>
+</h6>
+
+<p><font SIZE="2">TDWG Short name: UPDATEINST <br>
+</font></p>
+
+<p><font SIZE="2"><i>Description</i>: The institution where this record was last modified
+or updated. <br>
+</font></p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Alpha; uppercase, any valid Index
+Herbariorum code.<br>
+</font></p>
+
+<p><font SIZE="2"><i>Comments</i>: Although this information is described here, the
+contents of this field are equivalent to <b>Institution Code</b>.<br>
+</font></p>
+
+<p><font SIZE="2">This information would be very useful when institutions come to share
+data and sort out multiple modifications to the same specimen information.<br>
+<br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2"><a NAME="_Toc363917763">End of HISPID3 Record</a> </font></h4>
+
+<p><b>Transfer code: <font SIZE="5">}</font> </b></p>
+
+<p><font SIZE="2"><i>Description</i>: The single character } indicating the end of a
+HISPID3 Record.</font> </p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Must contain the symbol '}' only.</font> </p>
+
+<p><font SIZE="2"><i>Comments</i>: To be found at the end of each HISPID3 record
+indicating the end of the data of a record, prior to beginning the next record or the '<b>endfile'
+</b>identifier if it is the last record in the transfer file. <br>
+</font></p>
+
+<hr>
+
+<h4><font SIZE="2">End of HISPID3 File<!--FieldsEnd of HISPID3 File--></font> </h4>
+
+<h6><font SIZE="2">Transfer code: </font><font SIZE="4">endfile</font> <br>
+</h6>
+
+<p><font SIZE="2"><i>Description</i>: The end of the transfer file has the file identifier
+'endfile' only.</font> </p>
+
+<p><font SIZE="2"><i>Domain/Range/Values</i>: Must contain the transfer code 'endfile'
+only (all in lowercase).</font> </p>
+
+<p><font SIZE="2"><i>Comments</i>: To be found at the very end of a HISPID3 file
+indicating the end of the file.</font> </p>
+
+<hr>
+
+</body>
+</html>


### PR DESCRIPTION
## Changes to verbatim page
- Removed `(Cover page)` from title
- Chose CC-BY 4.0
- Changed dates to ISO
- Removed links for `status`, `category` and `task group`, as it is uncertain if those pages are going to remain. Just keep the text.
- Removed `permanent URL`
- Removed `Who's using this standard`, as there were no entries.
- Removed `Post a comment about your usage of this standard`. There were no comments. People can now comment via the issues.
- Removed old download link. Now links to download/110-540-1-RV.html
- The html file doesn't render on GitHub, but you can render it easily with [htmlpreview](http://htmlpreview.github.io/?https://github.com/tdwg/prior-standards/blob/master/hispid3/download/110-540-1-RV.html)
## Screenshot of http://www.tdwg.org/standards/110/

![tdwg standards](https://cloud.githubusercontent.com/assets/600993/4779854/360949cc-5c4a-11e4-8511-1493d7b60e0a.png)
